### PR TITLE
ENH: add DirectoryBackend

### DIFF
--- a/superscore/backends/__init__.py
+++ b/superscore/backends/__init__.py
@@ -18,6 +18,9 @@ def _get_backend(backend: str) -> _Backend:
     if backend == 'test':
         from .test import TestBackend
         return TestBackend
+    if backend == 'directory':
+        from .directory import DirectoryBackend
+        return DirectoryBackend
 
     raise ValueError(f"Unknown backend {backend}")
 
@@ -34,6 +37,11 @@ def _init_backends() -> Dict[str, _Backend]:
         backends['test'] = _get_backend('test')
     except ImportError as ex:
         logger.debug(f"Test Backend unavailable: {ex}")
+
+    try:
+        backends['directory'] = _get_backend('directory')
+    except ImportError as ex:
+        logger.debug(f"Directory Backend unavailable: {ex}")
 
     return backends
 

--- a/superscore/backends/directory.py
+++ b/superscore/backends/directory.py
@@ -1,0 +1,189 @@
+"""
+Backend for configurations backed by files within a directory
+"""
+
+import json
+import logging
+import os
+from functools import cache
+from typing import Container, Generator, Optional, Union
+from uuid import UUID, uuid4
+
+from apischema import deserialize, serialize
+
+from superscore.backends.core import SearchTermType, _Backend
+from superscore.errors import (BackendError, EntryExistsError,
+                               EntryNotFoundError)
+from superscore.model import Entry, Nestable, Root
+from superscore.utils import build_abs_path
+
+logger = logging.getLogger(__name__)
+
+RADIX_DEPTH = 3
+
+
+class DirectoryBackend(_Backend):
+    """"""
+    def __init__(
+        self,
+        path: str,
+        cfg_path: Optional[str] = None,
+    ) -> None:
+        self.path = path
+        if cfg_path is not None:
+            cfg_dir = os.path.dirname(cfg_path)
+            self.path = build_abs_path(cfg_dir, path)
+        try:
+            self.initialize()
+        except PermissionError:
+            pass
+
+    def get_entry(self, uuid: Union[UUID, str]) -> Entry:
+        path = self._find_entry_path(uuid)
+        try:
+            with open(path, 'r') as f:
+                serialized = json.load(f)
+        except FileNotFoundError as e:
+            raise EntryNotFoundError(e)
+        return deserialize(Entry, serialized)
+
+    def save_entry(self, entry: Entry, top_level: bool = True) -> None:
+        if top_level:
+            self.add_to_root(entry)
+        children = entry.swap_to_uuids()
+        for child in children:
+            if isinstance(child, Entry):
+                try:
+                    self.save_entry(child, top_level=False)
+                except FileExistsError:
+                    self.update_entry(child)
+
+        serialized = serialize(Entry, entry)
+        path = self._find_entry_path(entry.uuid)
+        try:
+            dir_path = os.path.dirname(path)
+            os.makedirs(dir_path, exist_ok=True)
+            with open(path, 'x') as f:
+                json.dump(serialized, f, indent=2)
+        except FileExistsError as e:
+            if top_level:
+                raise EntryExistsError(e)
+            else:
+                self.update_entry(entry)
+        except Exception:
+            # catch specific exceptions, not FileExistsError
+            # remove empty dirs in dir_path
+            raise
+
+    def delete_entry(self, entry: Entry) -> None:
+        # TODO: delete children
+        path = self._find_entry_path(entry.uuid)
+        os.remove(path)
+        dirname = os.path.dirname(path)
+        if len(os.listdir(dirname)) == 0:
+            os.removedirs(dirname)
+
+    def update_entry(self, entry: Entry) -> None:
+        # try to save children, then update; or vice-versa
+        try:
+            self.delete_entry(entry)
+        except FileNotFoundError as e:
+            raise BackendError(e)
+        self.save_entry(entry, top_level=False)
+
+    def search(self, *search_terms: SearchTermType) -> Generator[Entry, None, None]:
+        reachable = cache(self._gather_reachable)
+        for _, _, filenames in os.walk(self.path):
+            for filename in filenames:
+                if filename == "root.json":
+                    continue
+                uuid, _ = os.path.splitext(filename)
+                entry = self.get_entry(uuid)
+                conditions = []
+                for attr, op, target in search_terms:
+                    if attr == "entry_type":
+                        conditions.append(isinstance(entry, target))
+                    elif attr == "ancestor":
+                        # `target` must be UUID since `reachable` is cached
+                        conditions.append(entry.uuid in reachable(target))
+                    else:
+                        try:
+                            # check entry attribute by name
+                            value = getattr(entry, attr)
+                            conditions.append(self.compare(op, value, target))
+                        except AttributeError:
+                            conditions.append(False)
+                if all(conditions):
+                    yield entry
+
+    def _gather_reachable(self, ancestor: Union[Entry, UUID]) -> Container[UUID]:
+        """
+        Finds all entries accessible from ancestor, including ancestor, and returns
+        their UUIDs. This makes it easy to check if one entry is hierarchically under another.
+        """
+        reachable = set()
+        q = [ancestor]
+        while len(q) > 0:
+            cur = q.pop()
+            if not isinstance(cur, Entry):
+                cur = self.get_entry(cur)
+            reachable.add(cur.uuid)
+            if isinstance(cur, Nestable):
+                q.extend(cur.children)
+        return reachable
+
+    @property
+    def root(self) -> Root:
+        with open(os.path.join(self.path, "root.json"), 'r') as f:
+            serialized = json.load(f)
+        return deserialize(Root, serialized)
+
+    def add_to_root(self, entry: Entry):
+        root = self.root
+        root.entries.append(entry)
+        serialized = serialize(Root, root)
+        with open(os.path.join(self.path, "root.json"), 'w') as f:
+            json.dump(serialized, f, indent=2)
+
+    def initialize(self) -> None:
+        try:
+            os.mkdir(self.path)
+        except FileExistsError:
+            if os.path.exists(os.path.join(self.path, "root.json")):
+                raise PermissionError(f"Directory {self.path} already exists. Can not initialize "
+                                      "a new database.")
+
+        try:
+            with open(os.path.join(self.path, "root.json"), 'x') as f:
+                json.dump(serialize(Root, Root()), f, indent=2)
+        except Exception as e:
+            logger.debug("Failed to initialize db", exc_info=e)
+
+    def _temp_path(self) -> str:
+        """
+        Return a temporary path to write the json file to during "store".
+        Includes a hash for uniqueness
+        (in the cases where multiple temp files are written at once).
+        """
+        directory = os.path.dirname(self.path)
+        filename = (
+            f"_{str(uuid4())[:8]}"
+            f"_{os.path.basename(self.path)}"
+        )
+        return os.path.join(directory, filename)
+
+    def fill_uuids(self, entry: Entry) -> Entry:
+        pass
+
+    def _find_entry_path(self, uuid: Union[UUID, str]) -> str:
+        uuid = str(uuid)
+        segments = list(uuid.replace('-', ''))
+        internal_path = os.path.join(*segments[:RADIX_DEPTH])
+        return os.path.join(self.path, internal_path, f"{uuid}.json")
+
+    def reset(self) -> None:
+        for entry in self.search():
+            self.delete_entry(entry)
+        os.remove(os.path.join(self.path, "root.json"))
+        os.rmdir(self.path)
+        self.initialize()

--- a/superscore/backends/directory.py
+++ b/superscore/backends/directory.py
@@ -23,7 +23,12 @@ RADIX_DEPTH = 3
 
 
 class DirectoryBackend(_Backend):
-    """"""
+    """
+    Backend that stores each Entry as an individual file. Files are distributed into directories
+    according to the UUID of their Entry, to keep the number of files in each directory
+    reasonably small.
+    """
+
     def __init__(
         self,
         path: str,

--- a/superscore/backends/directory.py
+++ b/superscore/backends/directory.py
@@ -7,7 +7,7 @@ import logging
 import os
 from functools import cache
 from typing import Container, Generator, Optional, Union
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from apischema import deserialize, serialize
 
@@ -158,22 +158,6 @@ class DirectoryBackend(_Backend):
                 json.dump(serialize(Root, Root()), f, indent=2)
         except Exception as e:
             logger.debug("Failed to initialize db", exc_info=e)
-
-    def _temp_path(self) -> str:
-        """
-        Return a temporary path to write the json file to during "store".
-        Includes a hash for uniqueness
-        (in the cases where multiple temp files are written at once).
-        """
-        directory = os.path.dirname(self.path)
-        filename = (
-            f"_{str(uuid4())[:8]}"
-            f"_{os.path.basename(self.path)}"
-        )
-        return os.path.join(directory, filename)
-
-    def fill_uuids(self, entry: Entry) -> Entry:
-        pass
 
     def _find_entry_path(self, uuid: Union[UUID, str]) -> str:
         uuid = str(uuid)

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -1,5 +1,5 @@
 """
-Backend for configurations backed by files
+Backend for configurations backed by a single file
 """
 
 import contextlib
@@ -46,8 +46,6 @@ class FilestoreBackend(_Backend):
         if cfg_path is not None:
             cfg_dir = os.path.dirname(cfg_path)
             self.path = build_abs_path(cfg_dir, path)
-        else:
-            self.path = path
 
     def _load_or_initialize(self) -> Dict[str, Any]:
         """

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -338,3 +338,7 @@ class FilestoreBackend(_Backend):
         db = self._load_or_initialize()
         yield db
         self.store()
+
+    def reset(self) -> None:
+        with self._load_and_store_context():
+            self._entry_cache = {}

--- a/superscore/bin/demo_main.py
+++ b/superscore/bin/demo_main.py
@@ -21,8 +21,6 @@ def main(*args, db_path=None, **kwargs):
     parser.read(DEMO_CONFIG)
     if db_path is not None:
         db_path = Path(db_path)
-        if db_path.is_dir():
-            db_path /= 'superscore_demo.json'
         parser.set('backend', 'path', build_abs_path(Path.cwd(), db_path))
     client = Client.from_parsed_config(parser)
     # start with clean demo database

--- a/superscore/bin/demo_main.py
+++ b/superscore/bin/demo_main.py
@@ -31,6 +31,6 @@ def main(*args, db_path=None, **kwargs):
     source_names = parser.get("demo", "fixtures").split()
     populate_backend(client.backend, source_names)
     # IOCFactory needs the Entries with data
-    filled = [entry for entry in client.search() if isinstance(entry, (Setpoint, Readback))]
+    filled = list(client.search(("entry_type", "eq", (Setpoint, Readback))))
     with IOCFactory.from_entries(filled, client)(prefix=''):
         ui_main(*args, client=client, **kwargs)

--- a/superscore/bin/demo_main.py
+++ b/superscore/bin/demo_main.py
@@ -5,7 +5,6 @@ database pre-loaded
 Function components are separated from the arg parser to defer heavy imports
 """
 import configparser
-import os
 from pathlib import Path
 
 from superscore.backends.core import populate_backend
@@ -27,10 +26,7 @@ def main(*args, db_path=None, **kwargs):
         parser.set('backend', 'path', build_abs_path(Path.cwd(), db_path))
     client = Client.from_parsed_config(parser)
     # start with clean demo database
-    try:
-        os.remove(client.backend.path)
-    except FileNotFoundError:
-        pass
+    client.backend.reset()
     # write data from the sources to the backend
     source_names = parser.get("demo", "fixtures").split()
     populate_backend(client.backend, source_names)

--- a/superscore/bin/demo_main.py
+++ b/superscore/bin/demo_main.py
@@ -33,4 +33,4 @@ def main(*args, db_path=None, **kwargs):
     # IOCFactory needs the Entries with data
     filled = list(client.search(("entry_type", "eq", (Setpoint, Readback))))
     with IOCFactory.from_entries(filled, client)(prefix=''):
-        ui_main(*args, client=client, **kwargs)
+        ui_main(cfg_path=DEMO_CONFIG)

--- a/superscore/bin/ui_main.py
+++ b/superscore/bin/ui_main.py
@@ -15,7 +15,7 @@ DEFAULT_WIDTH = 1400
 DEFAULT_HEIGHT = 800
 
 
-def main(*args, cfg_path: Optional[str] = None, **kwargs):
+def main(cfg_path: Optional[str] = None):
     app = QApplication(sys.argv)
     if cfg_path:
         client = Client.from_config(cfg_path)

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Flag, IntEnum, auto
+from enum import IntEnum, auto
 from typing import ClassVar, List, Optional, Set, Union
 from uuid import UUID, uuid4
 
@@ -49,10 +49,6 @@ class Status(IntEnum):
     SIMM = auto()
     READ_ACCESS = auto()
     WRITE_ACCESS = auto()
-
-
-class Tag(Flag):
-    pass
 
 
 @as_tagged_union
@@ -215,11 +211,11 @@ class Nestable:
 class Collection(Nestable, Entry):
     """Nestable group of Parameters and Collections"""
     meta_pvs: ClassVar[List[Parameter]] = []
-    all_tags: ClassVar[Set[Tag]] = set()
+    all_tags: ClassVar[Set] = set()
 
     title: str = ""
     children: List[Union[UUID, Parameter, Collection]] = field(default_factory=list)
-    tags: Set[Tag] = field(default_factory=set)
+    tags: Set = field(default_factory=set)
 
     def swap_to_uuids(self) -> List[Entry]:
         # TODO: remove ref_list? copies .children by value, breaks refs?
@@ -249,7 +245,7 @@ class Snapshot(Nestable, Entry):
     children: List[Union[UUID, Readback, Setpoint, Snapshot]] = field(
         default_factory=list
     )
-    tags: Set[Tag] = field(default_factory=set)
+    tags: Set = field(default_factory=set)
     meta_pvs: List[Readback] = field(default_factory=list)
 
     def swap_to_uuids(self) -> List[Union[Entry, UUID]]:

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -222,6 +222,7 @@ class Collection(Nestable, Entry):
     tags: Set[Tag] = field(default_factory=set)
 
     def swap_to_uuids(self) -> List[Entry]:
+        # TODO: remove ref_list? copies .children by value, breaks refs?
         ref_list = []
 
         new_children = []

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -9,6 +9,7 @@ import apischema
 import pytest
 
 from superscore.backends.core import _Backend
+from superscore.backends.directory import DirectoryBackend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
 from superscore.client import Client
@@ -235,6 +236,8 @@ def test_backend(
         if backend_cls is FilestoreBackend:
             tmp_fp = tmp_path / 'tmp_filestore.json'
             backend = backend_cls(path=tmp_fp)
+        elif backend_cls is DirectoryBackend:
+            backend = backend_cls(path=tmp_path)
         else:
             backend = backend_cls()
 

--- a/superscore/tests/demo.cfg
+++ b/superscore/tests/demo.cfg
@@ -1,6 +1,6 @@
 [backend]
-type = filestore
-path = ~/superscore_demo.json
+type = directory
+path = ~/.superscore
 
 [control_layer]
 ca = true

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import pytest
 
 from superscore.backends.core import SearchTerm, _Backend
+from superscore.backends.directory import DirectoryBackend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
 from superscore.errors import (BackendError, EntryExistsError,
@@ -52,7 +53,7 @@ class TestTestBackend:
             linac_backend.delete_entry(unsynced)
 
 
-@setup_test_stack(backend_type=[FilestoreBackend, TestBackend])
+@setup_test_stack(backend_type=[FilestoreBackend, DirectoryBackend, TestBackend])
 def test_save_entry(test_backend: _Backend):
     new_entry = Parameter()
 
@@ -66,7 +67,7 @@ def test_save_entry(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_delete_entry(test_backend: _Backend):
     entry = test_backend.root.entries[0]
@@ -77,7 +78,7 @@ def test_delete_entry(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_search_entry(test_backend: _Backend):
     # Given an entry we know is in the backend
@@ -124,7 +125,7 @@ def test_search_entry(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_fuzzy_search(test_backend: _Backend):
     results = list(test_backend.search(
@@ -144,7 +145,7 @@ def test_fuzzy_search(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_tag_search(test_backend: _Backend):
     results = list(test_backend.search(
@@ -173,7 +174,7 @@ def test_tag_search(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_search_error(test_backend: _Backend):
     with pytest.raises(TypeError):
@@ -189,7 +190,7 @@ def test_search_error(test_backend: _Backend):
 
 
 @setup_test_stack(
-    sources=["db/filestore.json"], backend_type=[FilestoreBackend, TestBackend]
+    sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend, TestBackend]
 )
 def test_update_entry(test_backend: _Backend):
     # grab an entry from the database and modify it.
@@ -215,7 +216,7 @@ def test_update_entry(test_backend: _Backend):
 
 # TODO: Assess if _gather_reachable should be upstreamed to _Backend
 @setup_test_stack(
-    sources=["linac_data"], backend_type=FilestoreBackend,
+    sources=["linac_data"], backend_type=[FilestoreBackend, DirectoryBackend]
 )
 def test_gather_reachable(test_backend: _Backend):
     # top-level snapshot

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -1,4 +1,4 @@
-from enum import Flag, auto
+from enum import IntEnum, auto
 from uuid import UUID
 
 import pytest
@@ -152,7 +152,7 @@ def test_tag_search(test_backend: _Backend):
     ))
     assert len(results) == 2  # only the Collection and Snapshot have .tags
 
-    class Tag(Flag):
+    class Tag(IntEnum):
         T1 = auto()
         T2 = auto()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Implement `DirectoryBackend`, which disperses entries into multiple files within a directory
* Change demo config to use `DirectoryBackend`
* Adjust Tag type so serialization continues to work
* Introduce `_Backend.reset` to aid in testing and demos
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`FilestoreBackend` has very poor performance scaling, since the same large file has to read and written whenever data changes in the backend.  It also has extra complexity from `_entry_cache`, which is a common source of bugs due to improper cache invalidation and write-through handling.  `DirectoryBackend` is a solution to both of these problems, while also satisfying the need for a convenient testing / debugging backend.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`DirectoryBackend` has been inserted into existing backend tests, ensuring it has the same capabilities as existing backends.  Integration testing has been done manually.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This Pr
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
