### PR TITLE
BLD: update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/docs/source/upcoming_release_notes/4-bld_precommit_autoupdate.rst
+++ b/docs/source/upcoming_release_notes/4-bld_precommit_autoupdate.rst
@@ -1,0 +1,22 @@
+4 bld_precommit_autoupdate
+##########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- autoupdate pre-commit config
+
+Contributors
+------------
+- tangkong

--- a/superscore/tests/test_compare.py
+++ b/superscore/tests/test_compare.py
@@ -173,8 +173,8 @@ def test_client_diff(
     assert len(expected_diffs) == len(diff.diffs)
     for found_diff, expected_diff in zip(diff.diffs, expected_diffs):
         if isinstance(found_diff.original_value, Entry):
-            assert type(found_diff.original_value) == expected_diff.original_value
-            assert type(found_diff.new_value) == expected_diff.new_value
+            assert type(found_diff.original_value) is expected_diff.original_value
+            assert type(found_diff.new_value) is expected_diff.new_value
         else:
             assert found_diff.original_value == expected_diff.original_value
             assert found_diff.new_value == expected_diff.new_value


### PR DESCRIPTION
## Description
Run `pre-commit autoupdate`

## Motivation and Context
we recently updated our runners, which moved the default python version to 3.12.  For the test runners this doesn't matter since we make an env with a specific python version, but this broke some of the older the pre-commit check hooks (flake8)

I've been told this is more ammo for switching to ruff, but I'm lazy.
 
## How Has This Been Tested?
CI should pass


## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
