### PR TITLE
GUI: add snapshot table, without support for meta PV columns

### DIFF
--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -1,0 +1,51 @@
+from qtpy import QtCore
+
+from superscore.model import Snapshot
+
+HEADER = [
+    "TIMESTAMP",
+    "SNAPSHOT TITLE",
+]
+
+
+class SnapshotTableModel(QtCore.QAbstractTableModel):
+    """A table model containing all of the Snapshots available in a client"""
+
+    def __init__(self, client, parent=None):
+        super().__init__(parent)
+        self.client = client
+        self._data = list(self.client.search(
+            ("entry_type", "eq", Snapshot),
+        ))
+
+    def rowCount(self, parent=None):
+        return len(self._data)
+
+    def columnCount(self, parent=None):
+        return len(HEADER)
+
+    def data(
+        self,
+        index: QtCore.QModelIndex,
+        role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ):
+        if role == QtCore.Qt.DisplayRole:
+            entry = self._data[index.row()]
+            if (column := index.column()) == 0:
+                return entry.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+            elif column == 1:
+                return entry.title
+            else:
+                return None
+        else:
+            return None
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ):
+        if orientation == QtCore.Qt.Horizontal:
+            if role == QtCore.Qt.DisplayRole:
+                return HEADER[section]

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -21,6 +21,7 @@ from superscore.widgets.page.collection_builder import CollectionBuilderPage
 from superscore.widgets.page.diff import DiffPage
 from superscore.widgets.page.restore import RestorePage
 from superscore.widgets.page.search import SearchPage
+from superscore.widgets.snapshot_table import SnapshotTableModel
 from superscore.widgets.views import DiffDispatcher
 
 logger = logging.getLogger(__name__)
@@ -43,18 +44,34 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
 
     def setup_ui(self) -> None:
         navigation_panel = NavigationPanel()
+        navigation_panel.sigViewSnapshots.connect(self.open_snapshot_table)
+
+        self.snapshot_table = QtWidgets.QTableView()
+        self.snapshot_table.setModel(SnapshotTableModel(self.client))
+        self.snapshot_table.setStyleSheet(
+            "QTableView::item {"
+            "    border: 0px;"  # required to enforce padding on left side of cell
+            "    padding: 5px;"
+            "}"
+        )
+        self.snapshot_table.verticalHeader().hide()
+        header_view = self.snapshot_table.horizontalHeader()
+        header_view.setSectionResizeMode(header_view.ResizeToContents)
+        header_view.setSectionResizeMode(1, header_view.Stretch)
 
         splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        splitter.setChildrenCollapsible(False)
         splitter.addWidget(navigation_panel)
-        splitter.addWidget(QtWidgets.QFrame())
+        splitter.addWidget(self.snapshot_table)
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
-        splitter.setChildrenCollapsible(False)
-
         self.setCentralWidget(splitter)
 
         # open diff page
         self.diff_dispatcher.comparison_ready.connect(self.open_diff_page)
+
+    def open_snapshot_table(self):
+        self.centralWidget().replaceWidget(1, self.snapshot_table)
 
     def remove_tab(self, tab_index: int) -> None:
         """Remove the requested tab and delete the widget"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Implement `SnapshotTableModel`
* Instantiate `QTableView` connected to `SnapshotTableModel` in `Window.setup_ui()`

Relates to [SWAPPS-197](https://jira.slac.stanford.edu/browse/SWAPPS-197)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This table lets users browse Snapshots in chronological order.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests have been added or had to be modified.  Works interactively.
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
