### PR TITLE
TST: explicitly set date before searching in test_page::test_apply_filter

### DIFF
--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -147,6 +147,7 @@ def test_page_smoke(page: str, request: pytest.FixtureRequest):
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_apply_filter(test_client, search_page: SearchPage):
+    search_page.start_dt_edit.setDate(QtCore.QDate(2024, 5, 10))
     search_page.apply_filter_button.clicked.emit()
     assert search_page.results_table_view.model().rowCount() == 6
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* explicitly set date before searching in `test_page::test_apply_filter`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test relied on the test data having dates within the search page's range, but the search page set it's range to be the previous year.  The test data have a date of `10 May 2024`, so the test began failing on `10 May 2025`.  By explicitly setting the date range in the test, this type of sudden failure should not occur.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the test suite.

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
