### PR TITLE
ENH / GUI: add meta PV columns to snapshot table

### DIFF
--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -3,11 +3,11 @@ Base superscore data storage backend interface
 """
 import re
 from collections.abc import Container, Generator
-from typing import Callable, Iterable, NamedTuple, Union
+from typing import Callable, Iterable, NamedTuple, Sequence, Union
 from uuid import UUID
 
 import superscore.tests.conftest_data
-from superscore.model import Entry, Root
+from superscore.model import Entry, Parameter, Root
 from superscore.type_hints import AnyEpicsType, TagDef
 
 SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
@@ -126,6 +126,14 @@ class _Backend:
         """Set the definition of valid entry tags"""
         raise NotImplementedError
 
+    def get_meta_pvs(self) -> Sequence[Parameter]:
+        """Return the PVs used as Snapshot metadata"""
+        raise NotImplementedError
+
+    def set_meta_pvs(self, meta_pvs: Sequence[Parameter]) -> None:
+        """Set the PVs used as Snapshot metadata"""
+        raise NotImplementedError
+
 
 def populate_backend(backend: _Backend, sources: Iterable[Union[Callable, str, Root, Entry]]) -> None:
     """
@@ -151,5 +159,6 @@ def populate_backend(backend: _Backend, sources: Iterable[Union[Callable, str, R
             for entry in data.entries:
                 backend.save_entry(entry)
             backend.set_tags(data.tag_groups)
+            backend.set_meta_pvs(data.meta_pvs)
         else:
             backend.save_entry(data)

--- a/superscore/backends/directory.py
+++ b/superscore/backends/directory.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from functools import cache
-from typing import Container, Generator, Optional, Union
+from typing import Container, Generator, Optional, Sequence, Union
 from uuid import UUID
 
 from apischema import deserialize, serialize
@@ -14,7 +14,7 @@ from apischema import deserialize, serialize
 from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Entry, Nestable, Root
+from superscore.model import Entry, Nestable, Parameter, Root
 from superscore.type_hints import TagDef
 from superscore.utils import build_abs_path
 
@@ -178,6 +178,16 @@ class DirectoryBackend(_Backend):
     def set_tags(self, tags: TagDef) -> None:
         root = self.root
         root.tag_groups = tags
+        serialized = serialize(Root, root)
+        with open(os.path.join(self.path, "root.json"), 'w') as f:
+            json.dump(serialized, f, indent=2)
+
+    def get_meta_pvs(self) -> Sequence[Parameter]:
+        return self.root.meta_pvs
+
+    def set_meta_pvs(self, meta_pvs: Sequence[Parameter]) -> None:
+        root = self.root
+        root.meta_pvs = meta_pvs
         serialized = serialize(Root, root)
         with open(os.path.join(self.path, "root.json"), 'w') as f:
             json.dump(serialized, f, indent=2)

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from dataclasses import fields, replace
 from functools import cache
-from typing import Any, Container, Dict, Generator, Optional, Union
+from typing import Any, Container, Dict, Generator, Optional, Sequence, Union
 from uuid import UUID, uuid4
 
 from apischema import deserialize, serialize
@@ -17,7 +17,7 @@ from apischema import deserialize, serialize
 from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Entry, Nestable, Root
+from superscore.model import Entry, Nestable, Parameter, Root
 from superscore.type_hints import TagDef
 from superscore.utils import build_abs_path
 
@@ -347,6 +347,15 @@ class FilestoreBackend(_Backend):
     def set_tags(self, tags: TagDef) -> None:
         with self._load_and_store_context():
             self._root.tag_groups = tags
+
+    def get_meta_pvs(self) -> Sequence[Parameter]:
+        with self._load_and_store_context():
+            pvs = self._root.meta_pvs
+        return pvs
+
+    def set_meta_pvs(self, meta_pvs: Sequence[Parameter]) -> None:
+        with self._load_and_store_context():
+            self._root.meta_pvs = meta_pvs
 
     def reset(self) -> None:
         with self._load_and_store_context():

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -2,13 +2,13 @@
 Backend that manipulates Entries in-memory for testing purposes.
 """
 from copy import deepcopy
-from typing import Dict, Union
+from typing import Dict, Sequence, Union
 from uuid import UUID
 
 from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Entry, Nestable, Root
+from superscore.model import Entry, Nestable, Parameter, Root
 from superscore.type_hints import TagDef
 
 
@@ -105,3 +105,9 @@ class TestBackend(_Backend):
 
     def set_tags(self, tags: TagDef) -> None:
         self._root.tag_groups = tags
+
+    def get_meta_pvs(self) -> Sequence[Parameter]:
+        return self._root.meta_pvs
+
+    def set_meta_pvs(self, meta_pvs: Sequence[Parameter]) -> None:
+        self._root.meta_pvs = meta_pvs

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -265,7 +265,7 @@ class Client:
         """
         logger.debug(f"Saving Snapshot for Collection {entry.uuid}")
         pvs, _ = self._gather_data(entry)
-        pvs.extend(Collection.meta_pvs)
+        pvs.extend(self.backend.get_meta_pvs())
         values = self.cl.get(pvs)
         data = {}
         for pv, value in zip(pvs, values):
@@ -489,7 +489,7 @@ class Client:
                 snapshot.children.append(self._build_snapshot(child, values))
 
         snapshot.meta_pvs = []
-        for pv in Collection.meta_pvs:
+        for pv in self.backend.get_meta_pvs():
             edata = self._value_or_default(values.get(pv, None))
             readback = Readback(
                 pv_name=pv,

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import Iterable, List, Optional, Union
+from typing import List, Optional, Sequence, Union
 from uuid import UUID, uuid4
 
 import apischema
@@ -280,4 +280,4 @@ class Root:
     meta_id: UUID = _root_uuid
     entries: List[Entry] = field(default_factory=list)
     tag_groups: TagDef = field(default_factory=dict)
-    meta_pvs: Iterable[Parameter] = field(default_factory=list)
+    meta_pvs: Sequence[Parameter] = field(default_factory=list)

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import ClassVar, List, Optional, Union
+from typing import Iterable, List, Optional, Union
 from uuid import UUID, uuid4
 
 import apischema
@@ -215,8 +215,6 @@ class Nestable:
 @dataclass
 class Collection(Nestable, Entry):
     """Nestable group of Parameters and Collections"""
-    meta_pvs: ClassVar[List[Parameter]] = []
-
     title: str = ""
     children: List[Union[UUID, Parameter, Collection]] = field(default_factory=list)
     tags: TagSet = field(default_factory=dict)
@@ -282,3 +280,4 @@ class Root:
     meta_id: UUID = _root_uuid
     entries: List[Entry] = field(default_factory=list)
     tag_groups: TagDef = field(default_factory=dict)
+    meta_pvs: Iterable[Parameter] = field(default_factory=list)

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -647,7 +647,86 @@ def linac_data() -> Root:
         ],
     }
 
-    return Root(entries=[all_col, all_snapshot], tag_groups=tags)
+    hxr_pulse = Parameter(
+        uuid="653cf3f8-56d1-4409-b8d2-a31be09a9a20",
+        pv_name="DEST:HXR:PLSI",
+        description="HXR Pulse Intensity",
+        creation_time=now,
+        read_only=True,
+    )
+
+    sxr_pulse = Parameter(
+        uuid="3ed979c7-50ed-402f-9b6e-f3e5ebc1a18c",
+        pv_name="DEST:SXR:PLSI",
+        description="SXR Pulse Intensity",
+        creation_time=now,
+        read_only=True,
+    )
+
+    hxr_edes = Parameter(
+        uuid="006cbc48-5ead-4da7-9b3c-d4f4792c3bad",
+        pv_name="DEST:HXR:EDES",
+        description="HXR Energy Target",
+        creation_time=now,
+        read_only=True,
+    )
+
+    sxr_edes = Parameter(
+        uuid="51179e2b-53e1-417a-b6a9-4f20605d19bb",
+        pv_name="DEST:SXR:EDES",
+        description="SXR Energy Target",
+        creation_time=now,
+        read_only=True,
+    )
+
+    hxr_pulse_readback = Readback(
+        uuid="40451e72-575a-4069-a953-2d21af45c95f",
+        pv_name=hxr_pulse.pv_name,
+        description=hxr_pulse.description,
+        data=9.829,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
+    )
+
+    sxr_pulse_readback = Readback(
+        uuid="60819a50-db1b-415c-acf3-c57a2df6e5fe",
+        pv_name=sxr_pulse.pv_name,
+        description=sxr_pulse.description,
+        data=3.5,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
+    )
+
+    hxr_edes_readback = Readback(
+        uuid="8df5c8f7-9dc9-4555-9b17-d089551dafcc",
+        pv_name=hxr_edes.pv_name,
+        description=hxr_edes.description,
+        data=9.829,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
+    )
+
+    sxr_edes_readback = Readback(
+        uuid="61d3311b-fb72-40b7-bfac-9746e787abc9",
+        pv_name=sxr_edes.pv_name,
+        description=sxr_edes.description,
+        data=3.5,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
+    )
+
+    all_snapshot.meta_pvs = [
+        hxr_pulse_readback,
+        sxr_pulse_readback,
+        hxr_edes_readback,
+        sxr_edes_readback
+    ]
+
+    return Root(
+        entries=[all_col, all_snapshot],
+        tag_groups=tags,
+        meta_pvs=[hxr_pulse, hxr_edes, sxr_pulse, sxr_edes]
+    )
 
 
 def linac_with_comparison_snapshot() -> Root:

--- a/superscore/type_hints.py
+++ b/superscore/type_hints.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from superscore.model import Entry
     from superscore.widgets.core import DataWidget
 
-AnyEpicsType = Union[int, str, float, bool]
+AnyEpicsType = Union[float, str, bool, int]  # this order is important for apischema coercion
 TagDef = dict[int, list[Union[str, str, dict[int, str]]]]  # the definition of available tag groups
 TagSet = dict[int, set[int]]  # a set of active tags and tag groups attached to an entry
 

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -2,14 +2,14 @@ from qtpy import QtCore
 
 from superscore.model import Snapshot
 
-HEADER = [
-    "TIMESTAMP",
-    "SNAPSHOT TITLE",
-]
-
 
 class SnapshotTableModel(QtCore.QAbstractTableModel):
     """A table model containing all of the Snapshots available in a client"""
+
+    HEADER = [
+        "TIMESTAMP",
+        "SNAPSHOT TITLE",
+    ]
 
     def __init__(self, client, parent=None):
         super().__init__(parent)
@@ -22,7 +22,8 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
         return len(self._data)
 
     def columnCount(self, parent=None):
-        return len(HEADER)
+        meta_pvs = self.client.backend.get_meta_pvs()
+        return len(self.HEADER) + len(meta_pvs)
 
     def data(
         self,
@@ -36,7 +37,10 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
             elif column == 1:
                 return entry.title
             else:
-                return None
+                try:
+                    return entry.meta_pvs[column - len(self.HEADER)].data
+                except IndexError:
+                    return None
         else:
             return None
 
@@ -48,4 +52,8 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
     ):
         if orientation == QtCore.Qt.Horizontal:
             if role == QtCore.Qt.DisplayRole:
-                return HEADER[section]
+                try:
+                    return self.HEADER[section]
+                except IndexError:
+                    meta_pvs = self.client.backend.get_meta_pvs()
+                    return meta_pvs[section - len(self.HEADER)].description


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* move meta PVs definition out of `Collection` class def
* add meta PV getter and setter to backends
* add meta PV test data to `linac_data` fixture
* adjust `AnyEpicsType` type hint to improve coercion behaviour

Closes [SWAPPS-214](https://jira.slac.stanford.edu/browse/SWAPPS-214)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Meta PVs help users browse and identify snapshots in the snapshot table.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test suite passes
<!--
## Screenshots (if appropriate):
-->
![Screenshot 2025-05-15 at 10 23 12](https://github.com/user-attachments/assets/4953470a-3d25-4c1f-a4b5-4b2b6b8b713e)

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
