### PR TITLE
GUI: Expand/collapse nav panel, nav panel button style, refactor Window

### DIFF
--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -82,6 +82,7 @@ def test_pv_browser_search(qtbot, test_client):
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_nav_panel_expanded(qtbot, test_client):
+    """Passes if button property and text are correctly set when nav panel is expanded"""
     window = Window(client=test_client)
     qtbot.addWidget(window)
 
@@ -93,6 +94,7 @@ def test_nav_panel_expanded(qtbot, test_client):
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_nav_panel_collapsed(qtbot, test_client):
+    """Passes if button property and text are correctly set when nav panel is collapsed"""
     window = Window(client=test_client)
     qtbot.addWidget(window)
 
@@ -104,13 +106,17 @@ def test_nav_panel_collapsed(qtbot, test_client):
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_nav_panel_selected(qtbot, test_client):
+    """Passes if button property is correctly set when button is clicked, and the content
+    switched to the correct view"""
     window = Window(client=test_client)
     qtbot.addWidget(window)
 
     assert window.navigation_panel.view_snapshots_button.property("selected") is True
     assert window.navigation_panel.browse_pvs_button.property("selected") is False
+    assert window.main_content_stack.currentWidget() == window.snapshot_table
 
     window.navigation_panel.browse_pvs_button.click()
 
     assert window.navigation_panel.view_snapshots_button.property("selected") is False
     assert window.navigation_panel.browse_pvs_button.property("selected") is True
+    assert window.main_content_stack.currentWidget() == window.pv_browser_page

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -21,7 +21,7 @@ def count_visible_items(tree_view):
     return count
 
 
-@setup_test_stack(sources=['db/filestore.json'], backend_type=FilestoreBackend)
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_main_window(qtbot: QtBot, test_client: Client):
     """Pass if main window opens successfully"""
     window = Window(client=test_client)
@@ -39,7 +39,7 @@ def test_take_snapshot(qtbot, test_client):
     collection_page = window.open_page(collection)
     new_snapshot = collection_page.take_snapshot()
     collection_page.children()[-1].done(1)
-    search_result = tuple(test_client.search(("uuid", 'eq', new_snapshot.uuid)))
+    search_result = tuple(test_client.search(("uuid", "eq", new_snapshot.uuid)))
     assert new_snapshot == search_result[0]
 
     snapshot_page = window.open_page(snapshot)
@@ -51,7 +51,7 @@ def test_take_snapshot(qtbot, test_client):
     snapshot_page = window.open_page(snapshot)
     new_snapshot = snapshot_page.take_snapshot()
     snapshot_page.children()[-1].done(1)
-    search_result = tuple(test_client.search(("uuid", 'eq', new_snapshot.uuid)))
+    search_result = tuple(test_client.search(("uuid", "eq", new_snapshot.uuid)))
     assert new_snapshot == search_result[0]
 
 
@@ -78,3 +78,39 @@ def test_pv_browser_search(qtbot, test_client):
     assert pv_browser_filter.rowCount() == 3
     search_bar.setText("test_str")
     assert pv_browser_filter.rowCount() == 0
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_nav_panel_expanded(qtbot, test_client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    window.navigation_panel.set_expanded(True)
+
+    assert window.navigation_panel.view_snapshots_button.text() == "View Snapshots"
+    assert window.navigation_panel.view_snapshots_button.property("icon-only") is False
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_nav_panel_collapsed(qtbot, test_client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    window.navigation_panel.set_expanded(False)
+
+    assert window.navigation_panel.view_snapshots_button.text() == ""
+    assert window.navigation_panel.view_snapshots_button.property("icon-only") is True
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_nav_panel_selected(qtbot, test_client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    assert window.navigation_panel.view_snapshots_button.property("selected") is True
+    assert window.navigation_panel.browse_pvs_button.property("selected") is False
+
+    window.navigation_panel.browse_pvs_button.click()
+
+    assert window.navigation_panel.view_snapshots_button.property("selected") is False
+    assert window.navigation_panel.browse_pvs_button.property("selected") is True

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -328,6 +328,8 @@ class NavigationPanel(QtWidgets.QWidget):
         self.view_snapshots_button.setText("View Snapshots")
         self.view_snapshots_button.setFlat(True)
         self.view_snapshots_button.setToolTip("View Snapshots")
+        self.view_snapshots_button.setProperty("icon-only", False)
+        self.view_snapshots_button.setProperty("selected", False)
         self.view_snapshots_button.clicked.connect(self.sigViewSnapshots.emit)
         self.layout().addWidget(self.view_snapshots_button)
 
@@ -337,6 +339,8 @@ class NavigationPanel(QtWidgets.QWidget):
         self.browse_pvs_button.setText("Browse PVs")
         self.browse_pvs_button.setFlat(True)
         self.browse_pvs_button.setToolTip("Browse PVs")
+        self.browse_pvs_button.setProperty("icon-only", False)
+        self.browse_pvs_button.setProperty("selected", False)
         self.browse_pvs_button.clicked.connect(self.sigBrowsePVs.emit)
         self.layout().addWidget(self.browse_pvs_button)
 
@@ -346,6 +350,8 @@ class NavigationPanel(QtWidgets.QWidget):
         self.configure_tags_button.setText("Configure Tags")
         self.configure_tags_button.setFlat(True)
         self.configure_tags_button.setToolTip("Configure Tags")
+        self.configure_tags_button.setProperty("icon-only", False)
+        self.configure_tags_button.setProperty("selected", False)
         self.configure_tags_button.clicked.connect(self.sigConfigureTags.emit)
         self.layout().addWidget(self.configure_tags_button)
 
@@ -358,6 +364,7 @@ class NavigationPanel(QtWidgets.QWidget):
         self.toggle_expand_button.setIcon(qta.icon("ph.arrow-line-left"))
         self.toggle_expand_button.setIconSize(QtCore.QSize(24, 24))
         self.toggle_expand_button.setFlat(True)
+        self.toggle_expand_button.setProperty("icon-only", False)
         self.toggle_expand_button.clicked.connect(self.toggle_expanded)
         toggle_expand_layout.addWidget(self.toggle_expand_button)
         toggle_expand_layout.addStretch()
@@ -367,6 +374,7 @@ class NavigationPanel(QtWidgets.QWidget):
         self.save_button.setIcon(qta.icon("ph.instagram-logo"))
         self.save_button.setIconSize(QtCore.QSize(24, 24))
         self.save_button.setText("Save Snapshot")
+        self.save_button.setProperty("icon-only", False)
         self.save_button.clicked.connect(self.sigSave.emit)
         self.save_button.setObjectName("save-snapshot-btn")
         self.layout().addWidget(self.save_button)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Refactor Window:
  - use a StackedLayout to hold the different views - this means state persists even when changing view
  - remove Splitter as user control of navbar width is not necessary
  - refactoring to standardize how content views are initialized
  - individual snapshot views tracked in a dict to prevent duplicate views from spawning and allow for cleanup steps
- Navigation Panel functionality:
  - Style for buttons including hover
  - Expand and collapse panel including appropriate styling and content changes 
  - Tooltips for nav buttons so function can be understood even when collapsed
  - Button style for currently selected view only triggers when that view is actually rendered - you can see this with the not-yet-implemented Configure Tags view.
- Tests:
  - Test to check that switching views works
  - Tests to check that expanding and collapsing the nav panel set the appropriate properties
  - Test to check that the selected view styles the appropriate button.

[SWAPPS-222](https://jira.slac.stanford.edu/browse/SWAPPS-222)
[SWAPPS-223](https://jira.slac.stanford.edu/browse/SWAPPS-223)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests written for NavigationPanel, tested interactively.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings in code to describe important methods.

## Screenshots:

![image](https://github.com/user-attachments/assets/20719eca-dfd8-452f-8576-995e3ab65f41)
![image](https://github.com/user-attachments/assets/1793cbe8-fa42-4520-aee4-0e5384c34c71)

Mockup:
![image](https://github.com/user-attachments/assets/452ed412-7f5c-43d5-87c7-f657fe772cf0)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
