### PR TITLE
ENH: Snapshot Information on Snapshot Details Page

### DIFF
--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -1,0 +1,16 @@
+from qtpy import QtWidgets
+from qtpy.QtGui import QCloseEvent
+
+
+class Page(QtWidgets.QWidget):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
+        super().__init__(parent)
+        self.live_models = set()
+
+    def closeEvent(self, a0: QCloseEvent) -> None:
+        for model in self.live_models:
+            try:
+                model.close()
+            except AttributeError:
+                continue
+        super().closeEvent(a0)

--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -1,11 +1,13 @@
 from qtpy import QtWidgets
 from qtpy.QtGui import QCloseEvent
 
+from superscore.widgets.pv_table import PVTableModel
+
 
 class Page(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
-        self.live_models = set()
+        self.live_models: set[PVTableModel] = set()
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         for model in self.live_models:

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -31,7 +31,6 @@ class SnapshotDetailsPage(Page):
         self.snapshot = init_snapshot
 
         self.init_ui()
-        self.set_snapshot(init_snapshot)
 
     def init_ui(self) -> None:
         """Initialize the UI for the snapshot details page."""
@@ -55,6 +54,7 @@ class SnapshotDetailsPage(Page):
         spacer_label1.setStyleSheet("font: bold 18px")
         header_layout.addWidget(spacer_label1)
         self.snapshot_title_label = QtWidgets.QLabel()
+        self.snapshot_title_label.setText(self.snapshot.title)
         header_layout.addWidget(self.snapshot_title_label)
         spacer_label2 = QtWidgets.QLabel()
         spacer_label2.setText("|")
@@ -64,6 +64,8 @@ class SnapshotDetailsPage(Page):
         self.snapshot_time_label.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding,
             QtWidgets.QSizePolicy.Preferred,)
+        ts_str = self.snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+        self.snapshot_time_label.setText(ts_str)
         header_layout.addWidget(self.snapshot_time_label)
         snapshot_details_layout.addLayout(header_layout)
 
@@ -83,6 +85,7 @@ class SnapshotDetailsPage(Page):
 
         self.comparison_dialog = SnapshotComparisonDialog(self, self.client, self.snapshot)
         self.comparison_dialog.finished.connect(self.comparison_selected)
+        self.comparison_dialog.set_snapshot(self.snapshot)
         self.compare_button = QtWidgets.QPushButton(qta.icon("ph.plus"), "Compare", self)
         self.compare_button.clicked.connect(self.open_comparison_selection)
         interactions_layout.addWidget(self.compare_button)

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -1,0 +1,114 @@
+import qtawesome as qta
+from qtpy import QtCore, QtWidgets
+
+from superscore.client import Client
+from superscore.model import Snapshot
+from superscore.widgets.page.page import Page
+from superscore.widgets.pv_table import PV_HEADER, PVTableModel
+
+
+class SnapshotDetailsPage(Page):
+    """Snapshot details page for displaying the details of a snapshot."""
+
+    back_to_main_signal = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget, client: Client, init_snapshot: Snapshot):
+        """Initialize the snapshot details page.
+
+        Parameters
+        ----------
+        parent : QtWidgets.QWidget
+            Parent widget for the snapshot details page.
+        client : Client
+            Client object for interacting with the server.
+        init_snapshot : Snapshot
+            Snapshot object to be displayed in the details page.
+        """
+        super().__init__(parent)
+        self.client = client
+        self.snapshot = init_snapshot
+
+        self.init_ui()
+        self.set_snapshot(init_snapshot)
+
+    def init_ui(self) -> None:
+        """Initialize the UI for the snapshot details page."""
+        snapshot_details_layout = QtWidgets.QVBoxLayout()
+        snapshot_details_layout.setContentsMargins(0, 11, 0, 0)
+        self.setLayout(snapshot_details_layout)
+
+        header_layout = QtWidgets.QHBoxLayout()
+        back_button = QtWidgets.QPushButton()
+        back_button.setIcon(qta.icon("ph.arrow-left"))
+        back_button.setIconSize(QtCore.QSize(24, 24))
+        back_button.setStyleSheet("border: none")
+        back_button.clicked.connect(self.back_to_main_signal.emit)
+        header_layout.addWidget(back_button)
+
+        snapshot_label = QtWidgets.QLabel()
+        snapshot_label.setText("Snapshot")
+        header_layout.addWidget(snapshot_label)
+        spacer_label1 = QtWidgets.QLabel()
+        spacer_label1.setText("|")
+        spacer_label1.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label1)
+        self.snapshot_title_label = QtWidgets.QLabel()
+        header_layout.addWidget(self.snapshot_title_label)
+        spacer_label2 = QtWidgets.QLabel()
+        spacer_label2.setText("|")
+        spacer_label2.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label2)
+        self.snapshot_time_label = QtWidgets.QLabel()
+        self.snapshot_time_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Preferred,)
+        header_layout.addWidget(self.snapshot_time_label)
+        snapshot_details_layout.addLayout(header_layout)
+
+        interactions_layout = QtWidgets.QHBoxLayout()
+        self.search_bar = QtWidgets.QLineEdit()
+        self.search_bar.setClearButtonEnabled(True)
+        self.search_bar.addAction(
+            qta.icon("fa5s.search"),
+            QtWidgets.QLineEdit.LeadingPosition,
+        )
+        interactions_layout.addWidget(self.search_bar)
+        interactions_layout.addSpacerItem(QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
+        self.restore_button = QtWidgets.QPushButton(qta.icon("ph.arrow-clockwise"), "Restore", self)
+        self.restore_button.setEnabled(False)    # TODO: connect to restore function
+        # restore_button.clicked.connect()
+        interactions_layout.addWidget(self.restore_button)
+        self.compare_button = QtWidgets.QPushButton(qta.icon("ph.plus"), "Compare", self)
+        # compare_button.clicked.connect()    # TODO: connect to compare function
+        interactions_layout.addWidget(self.compare_button)
+        snapshot_details_layout.addLayout(interactions_layout)
+
+        # Create a snapshot details model, populated with first snapshot for initialization
+        self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
+        self.live_models.add(self.snapshot_details_model)
+
+        self.snapshot_details_table = QtWidgets.QTableView()
+        self.snapshot_details_table.setModel(self.snapshot_details_model)
+        self.snapshot_details_table.setShowGrid(False)
+        self.snapshot_details_table.verticalHeader().hide()
+        header_view = self.snapshot_details_table.horizontalHeader()
+        header_view.setSectionResizeMode(header_view.Stretch)
+        header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.PV.value, header_view.ResizeToContents)
+        snapshot_details_layout.addWidget(self.snapshot_details_table)
+
+    def set_snapshot(self, snapshot: Snapshot) -> None:
+        """Set the snapshot to be displayed in the details page."""
+        if not isinstance(snapshot, Snapshot):
+            raise TypeError("snapshot must be a Snapshot object")
+        if snapshot is self.snapshot:
+            return
+        self.snapshot = snapshot
+        self.snapshot_title_label.setText(self.snapshot.title)
+
+        ts_str = self.snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+        self.snapshot_time_label.setText(ts_str)
+
+        self.snapshot_details_model.set_snapshot(self.snapshot.uuid)

--- a/superscore/widgets/pv_table.py
+++ b/superscore/widgets/pv_table.py
@@ -167,3 +167,11 @@ class PVTableModel(LivePVTableModel):
                 self._checked.add(index.row())
             self.dataChanged.emit(index, index)
         return True
+
+    def set_snapshot(self, snapshot_id: UUID) -> None:
+        self._data = list(self.client.search(
+            ("ancestor", "eq", snapshot_id),
+            ("entry_type", "eq", (Setpoint, Readback)),
+        ))
+        self._checked = set()
+        self.set_entries(self._data)

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -49,3 +49,9 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
         if orientation == QtCore.Qt.Horizontal:
             if role == QtCore.Qt.DisplayRole:
                 return HEADER[section]
+
+    def index_to_snapshot(self, index: QtCore.QModelIndex) -> Snapshot:
+        """Convert a QModelIndex to a Snapshot object."""
+        if not (index and index.isValid()):
+            return None
+        return self._data[index.row()]

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -83,6 +83,34 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         snapshot_details_layout.setContentsMargins(0, 11, 0, 0)
         self.snapshot_details_page.setLayout(snapshot_details_layout)
 
+        header_layout = QtWidgets.QHBoxLayout()
+        back_button = QtWidgets.QPushButton()
+        back_button.setIcon(qta.icon("ph.arrow-left"))
+        back_button.setIconSize(QtCore.QSize(24, 24))
+        back_button.setStyleSheet("border: none")
+        back_button.clicked.connect(lambda: self.open_page(self.view_snapshot_page))
+        header_layout.addWidget(back_button)
+
+        snapshot_label = QtWidgets.QLabel()
+        snapshot_label.setText("Snapshot")
+        header_layout.addWidget(snapshot_label)
+        spacer_label1 = QtWidgets.QLabel()
+        spacer_label1.setText("|")
+        spacer_label1.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label1)
+        self.snapshot_title_label = QtWidgets.QLabel()
+        header_layout.addWidget(self.snapshot_title_label)
+        spacer_label2 = QtWidgets.QLabel()
+        spacer_label2.setText("|")
+        spacer_label2.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label2)
+        self.snapshot_time_label = QtWidgets.QLabel()
+        self.snapshot_time_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Preferred,)
+        header_layout.addWidget(self.snapshot_time_label)
+        snapshot_details_layout.addLayout(header_layout)
+
         # Create a snapshot details model, populated with first snapshot for initialization
         first_snapshot = self.snapshot_model.index_to_snapshot(self.snapshot_model.index(0, 0))
         snapshot_details_model = PVTableModel(first_snapshot.uuid, self.client)
@@ -144,6 +172,10 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             pass
 
         snapshot = self.snapshot_model.index_to_snapshot(snapshot_index)
+
+        self.snapshot_title_label.setText(snapshot.title)
+        self.snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
+
         snapshot_details_model = PVTableModel(snapshot.uuid, self.client)
         self.snapshot_details_table.setModel(snapshot_details_model)
         self.live_models.add(snapshot_details_model)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -4,23 +4,14 @@ Top-level window widget that contains other widgets
 from __future__ import annotations
 
 import logging
-from functools import partial
 from typing import Optional
 
 import qtawesome as qta
-from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
-from superscore.model import Entry, Snapshot
-from superscore.widgets import ICON_MAP
-from superscore.widgets.core import DataWidget, QtSingleton
-from superscore.widgets.page import PAGE_MAP
-from superscore.widgets.page.collection_builder import CollectionBuilderPage
-from superscore.widgets.page.diff import DiffPage
-from superscore.widgets.page.restore import RestorePage
-from superscore.widgets.page.search import SearchPage
+from superscore.widgets.core import QtSingleton
 from superscore.widgets.pv_browser_table import (PVBrowserFilterProxyModel,
                                                  PVBrowserTableModel)
 from superscore.widgets.pv_table import PV_HEADER, PVTableModel
@@ -42,42 +33,50 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.client = client
         else:
             self.client = Client.from_config()
-        self._partial_slots = []
+        self.live_models: set[PVTableModel] = set()
         self.setup_ui()
 
     def setup_ui(self) -> None:
-        navigation_panel = NavigationPanel()
-        navigation_panel.sigViewSnapshots.connect(self.open_snapshot_table)
-        navigation_panel.sigBrowsePVs.connect(self.open_pv_browser_page)
+        self.init_view_snapshot_page()
+        self.init_pv_browser_page()
 
-        self.snapshot_table = QtWidgets.QTableView()
-        self.snapshot_table.setModel(SnapshotTableModel(self.client))
-        self.snapshot_table.doubleClicked.connect(self.open_snapshot)
-        self.snapshot_table.setStyleSheet(
+        navigation_panel = NavigationPanel()
+        navigation_panel.sigViewSnapshots.connect(lambda: self.open_page(self.view_snapshot_page))
+        navigation_panel.sigBrowsePVs.connect(lambda: self.open_page(self.pv_browser_page))
+
+        self.splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        self.splitter.setChildrenCollapsible(False)
+        self.splitter.addWidget(navigation_panel)
+        self.splitter.addWidget(self.view_snapshot_page)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+
+        self.setWindowTitle("Superscore")
+        self.setCentralWidget(self.splitter)
+
+    def init_view_snapshot_page(self) -> None:
+        self.view_snapshot_page = QtWidgets.QWidget()
+        view_snapshot_layout = QtWidgets.QVBoxLayout()
+        view_snapshot_layout.setContentsMargins(0, 11, 0, 0)
+        self.view_snapshot_page.setLayout(view_snapshot_layout)
+
+        self.snapshot_model = SnapshotTableModel(self.client)
+        snapshot_table = QtWidgets.QTableView()
+        snapshot_table.setModel(self.snapshot_model)
+        snapshot_table.doubleClicked.connect(self.open_snapshot_details)
+        snapshot_table.setStyleSheet(
             "QTableView::item {"
             "    border: 0px;"  # required to enforce padding on left side of cell
             "    padding: 5px;"
             "}"
         )
-        self.snapshot_table.verticalHeader().hide()
-        header_view = self.snapshot_table.horizontalHeader()
+        snapshot_table.verticalHeader().hide()
+        header_view = snapshot_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeToContents)
         header_view.setSectionResizeMode(1, header_view.Stretch)
+        view_snapshot_layout.addWidget(snapshot_table)
 
-        self.init_pv_browser_page()
-
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
-        splitter.setChildrenCollapsible(False)
-        splitter.addWidget(navigation_panel)
-        splitter.addWidget(self.snapshot_table)
-        splitter.setStretchFactor(0, 0)
-        splitter.setStretchFactor(1, 1)
-        self.setCentralWidget(splitter)
-
-        # open diff page
-        self.diff_dispatcher.comparison_ready.connect(self.open_diff_page)
-
-    def init_pv_browser_page(self) -> QtWidgets.QWidget:
+    def init_pv_browser_page(self) -> None:
         """Initialize the PV browser page with the PV browser table."""
         pv_browser_model = PVBrowserTableModel(self.client)
         pv_browser_filter = PVBrowserFilterProxyModel()
@@ -109,140 +108,36 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         header_view.setStretchLastSection(True)
         pv_browser_layout.addWidget(self.pv_browser_table)
 
-    def open_pv_browser_page(self) -> None:
-        """Open the PV Browser Page if it is not already open."""
-        curr_widget = self.centralWidget().widget(1)
-        if curr_widget is self.pv_browser_page:
-            return
-        self.centralWidget().replaceWidget(1, self.pv_browser_page)
-        self.centralWidget().setStretchFactor(1, 1)
+    def open_snapshot_details(self, index: QtCore.QModelIndex) -> None:
+        snapshot = self.snapshot_model.index_to_snapshot(index)
+        snapshot_details_model = PVTableModel(snapshot.uuid, self.client)
+        self.live_models.add(snapshot_details_model)
 
-    def open_snapshot_table(self):
-        if self.centralWidget().widget(1) != self.snapshot_table:
-            self.centralWidget().replaceWidget(1, self.snapshot_table)
-
-    def open_snapshot(self, index: QtCore.Qt.QModelIndex) -> None:
-        snapshot = self.snapshot_table.model()._data[index.row()]
-        pv_table = QtWidgets.QTableView()
-        pv_table.setModel(PVTableModel(snapshot.uuid, self.client))
-        pv_table.destroyed.connect(pv_table.model().close)
-        pv_table.setShowGrid(False)
-        pv_table.verticalHeader().hide()
-        header_view = pv_table.horizontalHeader()
+        snapshot_details_table = QtWidgets.QTableView()
+        snapshot_details_table.setModel(snapshot_details_model)
+        snapshot_details_table.destroyed.connect(snapshot_details_model.close)
+        snapshot_details_table.setShowGrid(False)
+        snapshot_details_table.verticalHeader().hide()
+        header_view = snapshot_details_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Stretch)
         header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeToContents)
         header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeToContents)
         header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeToContents)
         header_view.setSectionResizeMode(PV_HEADER.PV.value, header_view.ResizeToContents)
 
-        self.centralWidget().replaceWidget(1, pv_table)
-        self.centralWidget().setStretchFactor(1, 1)
+        self.open_page(snapshot_details_table)
 
-    def remove_tab(self, tab_index: int) -> None:
-        """Remove the requested tab and delete the widget"""
-        widget = self.tab_widget.widget(tab_index)
-        widget.close()
-        widget.deleteLater()
-        self.tab_widget.removeTab(tab_index)
-
-    def _update_tab_title(self, tab_index: int) -> None:
-        """Update a DataWidget tab title.  Assumes widget.title exists"""
-        title_text = self.tab_widget.widget(tab_index)._title
-        self.tab_widget.setTabText(tab_index, title_text)
-
-    def open_collection_builder(self):
-        """open collection builder page"""
-        page = CollectionBuilderPage(client=self.client)
-        self.tab_widget.addTab(page, 'new collection')
-        self.tab_widget.setCurrentWidget(page)
-        update_slot = WeakPartialMethodSlot(
-            page.bridge.title, page.bridge.title.updated,
-            self._update_tab_title,
-            tab_index=self.tab_widget.indexOf(page),
-        )
-        self._partial_slots.append(update_slot)
-
-    def open_page(self, entry: Entry) -> DataWidget:
-        """
-        Open a page for ``entry`` in a new tab.
-
-        Parameters
-        ----------
-        entry : Entry
-            Entry subclass to open a new page for
-
-        Returns
-        -------
-        DataWidget
-            Created widget, for cross references
-        """
-        logger.debug(f'attempting to open {entry}')
-        if not isinstance(entry, Entry):
-            logger.debug('Could not open page for non-Entry dataclass')
+    def open_page(self, page: QtWidgets.QWidget) -> None:
+        """Open a page in the main window."""
+        curr_widget = self.splitter.widget(1)
+        if curr_widget is page:
             return
-
-        if type(entry) not in PAGE_MAP:
-            logger.debug(f'No page corresponding to {type(entry).__name__}')
-
-        try:
-            page = PAGE_MAP[type(entry)]
-        except KeyError:
-            logger.debug(f'No page widget for {type(entry)}, cannot open in tab')
-            return
-
-        page_widget = page(data=entry, client=self.client)
-        icon = qta.icon(ICON_MAP[type(entry)])
-        tab_name = getattr(
-            entry, 'title', getattr(entry, 'pv_name', f'<{type(entry).__name__}>')
-        )
-        idx = self.tab_widget.addTab(page_widget, icon, tab_name)
-        self.tab_widget.setCurrentIndex(idx)
-
-        return page_widget
-
-    def open_index(self, index: QtCore.QModelIndex) -> None:
-        entry: Entry = index.internalPointer()._data
-        self.open_page(entry)
-
-    def open_search_page(self) -> None:
-        page = SearchPage(client=self.client)
-        index = self.tab_widget.addTab(page, 'search')
-        self.tab_widget.setCurrentIndex(index)
-
-    def open_restore_page(self, snapshot: Snapshot) -> None:
-        page = RestorePage(data=snapshot, client=self.client)
-        index = self.tab_widget.addTab(page, snapshot.title)
-        self.tab_widget.setCurrentIndex(index)
-
-    def open_diff_page(self) -> None:
-        page = DiffPage(
-            client=self.client,
-            l_entry=self.diff_dispatcher.l_entry,
-            r_entry=self.diff_dispatcher.r_entry,
-        )
-        index = self.tab_widget.addTab(page, 'Comparison View')
-        self.tab_widget.setCurrentIndex(index)
-
-    def _window_context_menu(self, entry: Entry) -> QtWidgets.QMenu:
-        """override for RootTreeView context menu"""
-        menu = QtWidgets.QMenu(self)
-        open_action = menu.addAction(
-            f'&Open Detailed {type(entry).__name__} page'
-        )
-        # WeakPartialMethodSlot may not be needed, menus are transient
-        open_action.triggered.connect(partial(self.open_page, entry))
-        if isinstance(entry, Snapshot):
-            restore_page_action = menu.addAction('Inspect values')
-            restore_page_action.triggered.connect(partial(self.open_restore_page, entry))
-
-        return menu
+        self.splitter.replaceWidget(1, page)
+        self.splitter.setStretchFactor(1, 1)
 
     def closeEvent(self, a0: QCloseEvent) -> None:
-        try:
-            self.centralWidget().widget(1).model().stop_polling(wait_time=5000)
-            self.centralWidget().widget(1).close()
-        except AttributeError:
-            pass
+        for model in self.live_models:
+            model.close()
         super().closeEvent(a0)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add the details for a snapshot to the Snapshot Details page. This tells the user the title and creation time of the selected snapshot.

In addition, I made a paging system for the main application. This consists of a Page widget that the Snapshot Details page subclasses. This resulted in a lot of moving code to a new file, which is why the PR is so large.

## Motivation and Context
[SWAPPS-224](https://jira.slac.stanford.edu/browse/SWAPPS-224)

## How Has This Been Tested?
Interactively
<!--
## Screenshots (if appropriate):
-->
![Screenshot 2025-05-20 at 10 11 27](https://github.com/user-attachments/assets/60de99eb-2842-4761-af2e-649674935e14)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
