### PR TITLE
 ENH: Snapshot Information on Snapshot Details Page

### DIFF
--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -113,7 +113,7 @@ def test_nav_panel_selected(qtbot, test_client):
 
     assert window.navigation_panel.view_snapshots_button.property("selected") is True
     assert window.navigation_panel.browse_pvs_button.property("selected") is False
-    assert window.main_content_stack.currentWidget() == window.snapshot_table
+    assert window.main_content_stack.currentWidget() == window.view_snapshot_page
 
     window.navigation_panel.browse_pvs_button.click()
 

--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -1,18 +1,23 @@
+from logging import getLogger
+from uuid import UUID
+
 from qtpy import QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.widgets.pv_table import PVTableModel
 
+logger = getLogger(__name__)
+
 
 class Page(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
-        self.live_models: set[PVTableModel] = set()
+        self.pv_table_models: dict[UUID: PVTableModel] = {}
 
     def closeEvent(self, a0: QCloseEvent) -> None:
-        for model in self.live_models:
+        for model in self.pv_table_models.values():
             try:
                 model.close()
             except AttributeError:
-                continue
+                logger.warning(f"Model {model} does not have a close method.")
         super().closeEvent(a0)

--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -1,0 +1,16 @@
+from qtpy import QtWidgets
+from qtpy.QtGui import QCloseEvent
+
+
+class Page(QtWidgets.QWidget):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
+        super().__init__(parent)
+        self.live_models = set()
+
+    def closeEvent(self, a0: QCloseEvent) -> None:
+        for model in self.live_models:
+            try:
+                model.close()
+            except AttributeError:
+                continue
+        super().closeEvent(a0)

--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -1,11 +1,13 @@
 from qtpy import QtWidgets
 from qtpy.QtGui import QCloseEvent
 
+from superscore.widgets.pv_table import PVTableModel
+
 
 class Page(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
-        self.live_models = set()
+        self.live_models: set[PVTableModel] = set()
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         for model in self.live_models:

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -31,7 +31,6 @@ class SnapshotDetailsPage(Page):
         self.snapshot = init_snapshot
 
         self.init_ui()
-        self.set_snapshot(init_snapshot)
 
     def init_ui(self) -> None:
         """Initialize the UI for the snapshot details page."""
@@ -55,6 +54,7 @@ class SnapshotDetailsPage(Page):
         spacer_label1.setStyleSheet("font: bold 18px")
         header_layout.addWidget(spacer_label1)
         self.snapshot_title_label = QtWidgets.QLabel()
+        self.snapshot_title_label.setText(self.snapshot.title)
         header_layout.addWidget(self.snapshot_title_label)
         spacer_label2 = QtWidgets.QLabel()
         spacer_label2.setText("|")
@@ -64,6 +64,8 @@ class SnapshotDetailsPage(Page):
         self.snapshot_time_label.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding,
             QtWidgets.QSizePolicy.Preferred,)
+        ts_str = self.snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+        self.snapshot_time_label.setText(ts_str)
         header_layout.addWidget(self.snapshot_time_label)
         snapshot_details_layout.addLayout(header_layout)
 
@@ -83,6 +85,7 @@ class SnapshotDetailsPage(Page):
 
         self.comparison_dialog = SnapshotComparisonDialog(self, self.client, self.snapshot)
         self.comparison_dialog.finished.connect(self.comparison_selected)
+        self.comparison_dialog.set_snapshot(self.snapshot)
         self.compare_button = QtWidgets.QPushButton(qta.icon("ph.plus"), "Compare", self)
         self.compare_button.clicked.connect(self.open_comparison_selection)
         interactions_layout.addWidget(self.compare_button)

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -93,7 +93,7 @@ class SnapshotDetailsPage(Page):
 
         # Create a snapshot details model, populated with first snapshot for initialization
         self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
-        self.live_models.add(self.snapshot_details_model)
+        self.pv_table_models[self.snapshot.uuid] = self.snapshot_details_model
 
         self.snapshot_details_table = QtWidgets.QTableView()
         self.snapshot_details_table.setModel(self.snapshot_details_model)
@@ -119,7 +119,12 @@ class SnapshotDetailsPage(Page):
         ts_str = self.snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
         self.snapshot_time_label.setText(ts_str)
 
-        self.snapshot_details_model.set_snapshot(self.snapshot.uuid)
+        if self.snapshot.uuid in self.pv_table_models:
+            self.snapshot_details_model = self.pv_table_models[self.snapshot.uuid]
+        else:
+            self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
+            self.pv_table_models[self.snapshot.uuid] = self.snapshot_details_model
+        self.snapshot_details_table.setModel(self.snapshot_details_model)
 
         self.comparison_dialog.set_snapshot(self.snapshot)
 

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -1,0 +1,114 @@
+import qtawesome as qta
+from qtpy import QtCore, QtWidgets
+
+from superscore.client import Client
+from superscore.model import Snapshot
+from superscore.widgets.page.page import Page
+from superscore.widgets.pv_table import PV_HEADER, PVTableModel
+
+
+class SnapshotDetailsPage(Page):
+    """Snapshot details page for displaying the details of a snapshot."""
+
+    back_to_main_signal = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget, client: Client, init_snapshot: Snapshot):
+        """Initialize the snapshot details page.
+
+        Parameters
+        ----------
+        parent : QtWidgets.QWidget
+            Parent widget for the snapshot details page.
+        client : Client
+            Client object for interacting with the server.
+        init_snapshot : Snapshot
+            Snapshot object to be displayed in the details page.
+        """
+        super().__init__(parent)
+        self.client = client
+        self.snapshot = init_snapshot
+
+        self.init_ui()
+        self.set_snapshot(init_snapshot)
+
+    def init_ui(self) -> None:
+        """Initialize the UI for the snapshot details page."""
+        snapshot_details_layout = QtWidgets.QVBoxLayout()
+        snapshot_details_layout.setContentsMargins(0, 11, 0, 0)
+        self.setLayout(snapshot_details_layout)
+
+        header_layout = QtWidgets.QHBoxLayout()
+        back_button = QtWidgets.QPushButton()
+        back_button.setIcon(qta.icon("ph.arrow-left"))
+        back_button.setIconSize(QtCore.QSize(24, 24))
+        back_button.setStyleSheet("border: none")
+        back_button.clicked.connect(self.back_to_main_signal.emit)
+        header_layout.addWidget(back_button)
+
+        snapshot_label = QtWidgets.QLabel()
+        snapshot_label.setText("Snapshot")
+        header_layout.addWidget(snapshot_label)
+        spacer_label1 = QtWidgets.QLabel()
+        spacer_label1.setText("|")
+        spacer_label1.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label1)
+        self.snapshot_title_label = QtWidgets.QLabel()
+        header_layout.addWidget(self.snapshot_title_label)
+        spacer_label2 = QtWidgets.QLabel()
+        spacer_label2.setText("|")
+        spacer_label2.setStyleSheet("font: bold 18px")
+        header_layout.addWidget(spacer_label2)
+        self.snapshot_time_label = QtWidgets.QLabel()
+        self.snapshot_time_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Preferred,)
+        header_layout.addWidget(self.snapshot_time_label)
+        snapshot_details_layout.addLayout(header_layout)
+
+        interactions_layout = QtWidgets.QHBoxLayout()
+        self.search_bar = QtWidgets.QLineEdit()
+        self.search_bar.setClearButtonEnabled(True)
+        self.search_bar.addAction(
+            qta.icon("fa5s.search"),
+            QtWidgets.QLineEdit.LeadingPosition,
+        )
+        interactions_layout.addWidget(self.search_bar)
+        interactions_layout.addSpacerItem(QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
+        self.restore_button = QtWidgets.QPushButton(qta.icon("ph.arrow-clockwise"), "Restore", self)
+        self.restore_button.setEnabled(False)    # TODO: connect to restore function
+        # restore_button.clicked.connect()
+        interactions_layout.addWidget(self.restore_button)
+        self.compare_button = QtWidgets.QPushButton(qta.icon("ph.plus"), "Compare", self)
+        # compare_button.clicked.connect()    # TODO: connect to compare function
+        interactions_layout.addWidget(self.compare_button)
+        snapshot_details_layout.addLayout(interactions_layout)
+
+        # Create a snapshot details model, populated with first snapshot for initialization
+        self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
+        self.live_models.add(self.snapshot_details_model)
+
+        self.snapshot_details_table = QtWidgets.QTableView()
+        self.snapshot_details_table.setModel(self.snapshot_details_model)
+        self.snapshot_details_table.setShowGrid(False)
+        self.snapshot_details_table.verticalHeader().hide()
+        header_view = self.snapshot_details_table.horizontalHeader()
+        header_view.setSectionResizeMode(header_view.Stretch)
+        header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.PV.value, header_view.ResizeToContents)
+        snapshot_details_layout.addWidget(self.snapshot_details_table)
+
+    def set_snapshot(self, snapshot: Snapshot) -> None:
+        """Set the snapshot to be displayed in the details page."""
+        if not isinstance(snapshot, Snapshot):
+            raise TypeError("snapshot must be a Snapshot object")
+        if snapshot is self.snapshot:
+            return
+        self.snapshot = snapshot
+        self.snapshot_title_label.setText(self.snapshot.title)
+
+        ts_str = self.snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+        self.snapshot_time_label.setText(ts_str)
+
+        self.snapshot_details_model.set_snapshot(self.snapshot.uuid)

--- a/superscore/widgets/pv_table.py
+++ b/superscore/widgets/pv_table.py
@@ -167,3 +167,11 @@ class PVTableModel(LivePVTableModel):
                 self._checked.add(index.row())
             self.dataChanged.emit(index, index)
         return True
+
+    def set_snapshot(self, snapshot_id: UUID) -> None:
+        self._data = list(self.client.search(
+            ("ancestor", "eq", snapshot_id),
+            ("entry_type", "eq", (Setpoint, Readback)),
+        ))
+        self._checked = set()
+        self.set_entries(self._data)

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -57,3 +57,9 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
                 except IndexError:
                     meta_pvs = self.client.backend.get_meta_pvs()
                     return meta_pvs[section - len(self.HEADER)].description
+
+    def index_to_snapshot(self, index: QtCore.QModelIndex) -> Snapshot:
+        """Convert a QModelIndex to a Snapshot object."""
+        if not (index and index.isValid()):
+            return None
+        return self._data[index.row()]

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -5,23 +5,14 @@ Top-level window widget that contains other widgets
 from __future__ import annotations
 
 import logging
-from functools import partial
 from typing import Optional
 
 import qtawesome as qta
-from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
-from superscore.model import Entry, Snapshot
-from superscore.widgets import ICON_MAP
-from superscore.widgets.core import DataWidget, QtSingleton
-from superscore.widgets.page import PAGE_MAP
-from superscore.widgets.page.collection_builder import CollectionBuilderPage
-from superscore.widgets.page.diff import DiffPage
-from superscore.widgets.page.restore import RestorePage
-from superscore.widgets.page.search import SearchPage
+from superscore.widgets.core import QtSingleton
 from superscore.widgets.pv_browser_table import (PVBrowserFilterProxyModel,
                                                  PVBrowserTableModel)
 from superscore.widgets.pv_table import PV_HEADER, PVTableModel
@@ -51,7 +42,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.navigation_panel = self.init_nav_panel()
 
         # Initialize content pages and add to stack
-        self.snapshot_table = self.init_snapshot_table()
+        self.view_snapshot_page = self.init_view_snapshot_page()
         self.pv_browser_page = self.init_pv_browser_page()
 
         self.main_content_stack = QtWidgets.QStackedLayout()
@@ -71,9 +62,6 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         central_widget.layout().setContentsMargins(0, 0, 0, 0)
         self.setCentralWidget(central_widget)
 
-        # open diff page
-        self.diff_dispatcher.comparison_ready.connect(self.open_diff_page)
-
     def init_nav_panel(self) -> NavigationPanel:
         navigation_panel = NavigationPanel()
         navigation_panel.sigViewSnapshots.connect(self.open_snapshot_table)
@@ -82,8 +70,14 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         navigation_panel.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
         return navigation_panel
 
-    def init_snapshot_table(self) -> QtWidgets.QTableView:
+    def init_view_snapshot_page(self) -> QtWidgets.QWidget:
         """Initialize the snapshot page"""
+        view_snapshot_page = QtWidgets.QWidget()
+        view_snapshot_layout = QtWidgets.QVBoxLayout()
+        view_snapshot_layout.setContentsMargins(0, 11, 0, 0)
+        view_snapshot_page.setLayout(view_snapshot_layout)
+
+
         snapshot_table = QtWidgets.QTableView()
         snapshot_table.setModel(SnapshotTableModel(self.client))
         snapshot_table.doubleClicked.connect(self.open_snapshot)
@@ -97,7 +91,8 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         header_view = snapshot_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeToContents)
         header_view.setSectionResizeMode(1, header_view.Stretch)
-        return snapshot_table
+        view_snapshot_layout.addWidget(snapshot_table)
+        return view_snapshot_page
 
     def init_pv_browser_page(self) -> QtWidgets.QWidget:
         """Initialize the PV browser page with the PV browser table."""
@@ -144,6 +139,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.main_content_stack.setCurrentWidget(self.snapshot_table)
             self.navigation_panel.set_nav_button_selected(self.navigation_panel.view_snapshots_button)
 
+    @QtCore.Slot(QtCore.Qt.QModelIndex)
     def open_snapshot(self, index: QtCore.Qt.QModelIndex) -> None:
         """Opens the snapshot stored at the selected index. A widget representing the
         snapshot is created if necessary and set as the current view in the stack.
@@ -173,102 +169,6 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             pv_table = self.pv_tables_in_stack[snapshot.uuid]
 
         self.main_content_stack.setCurrentWidget(pv_table)
-
-    def remove_tab(self, tab_index: int) -> None:
-        """Remove the requested tab and delete the widget"""
-        widget = self.tab_widget.widget(tab_index)
-        widget.close()
-        widget.deleteLater()
-        self.tab_widget.removeTab(tab_index)
-
-    def _update_tab_title(self, tab_index: int) -> None:
-        """Update a DataWidget tab title.  Assumes widget.title exists"""
-        title_text = self.tab_widget.widget(tab_index)._title
-        self.tab_widget.setTabText(tab_index, title_text)
-
-    def open_collection_builder(self):
-        """open collection builder page"""
-        page = CollectionBuilderPage(client=self.client)
-        self.tab_widget.addTab(page, "new collection")
-        self.tab_widget.setCurrentWidget(page)
-        update_slot = WeakPartialMethodSlot(
-            page.bridge.title,
-            page.bridge.title.updated,
-            self._update_tab_title,
-            tab_index=self.tab_widget.indexOf(page),
-        )
-        self._partial_slots.append(update_slot)
-
-    def open_page(self, entry: Entry) -> DataWidget:
-        """
-        Open a page for ``entry`` in a new tab.
-
-        Parameters
-        ----------
-        entry : Entry
-            Entry subclass to open a new page for
-
-        Returns
-        -------
-        DataWidget
-            Created widget, for cross references
-        """
-        logger.debug(f"attempting to open {entry}")
-        if not isinstance(entry, Entry):
-            logger.debug("Could not open page for non-Entry dataclass")
-            return
-
-        if type(entry) not in PAGE_MAP:
-            logger.debug(f"No page corresponding to {type(entry).__name__}")
-
-        try:
-            page = PAGE_MAP[type(entry)]
-        except KeyError:
-            logger.debug(f"No page widget for {type(entry)}, cannot open in tab")
-            return
-
-        page_widget = page(data=entry, client=self.client)
-        icon = qta.icon(ICON_MAP[type(entry)])
-        tab_name = getattr(entry, "title", getattr(entry, "pv_name", f"<{type(entry).__name__}>"))
-        idx = self.tab_widget.addTab(page_widget, icon, tab_name)
-        self.tab_widget.setCurrentIndex(idx)
-
-        return page_widget
-
-    def open_index(self, index: QtCore.QModelIndex) -> None:
-        entry: Entry = index.internalPointer()._data
-        self.open_page(entry)
-
-    def open_search_page(self) -> None:
-        page = SearchPage(client=self.client)
-        index = self.tab_widget.addTab(page, "search")
-        self.tab_widget.setCurrentIndex(index)
-
-    def open_restore_page(self, snapshot: Snapshot) -> None:
-        page = RestorePage(data=snapshot, client=self.client)
-        index = self.tab_widget.addTab(page, snapshot.title)
-        self.tab_widget.setCurrentIndex(index)
-
-    def open_diff_page(self) -> None:
-        page = DiffPage(
-            client=self.client,
-            l_entry=self.diff_dispatcher.l_entry,
-            r_entry=self.diff_dispatcher.r_entry,
-        )
-        index = self.tab_widget.addTab(page, "Comparison View")
-        self.tab_widget.setCurrentIndex(index)
-
-    def _window_context_menu(self, entry: Entry) -> QtWidgets.QMenu:
-        """override for RootTreeView context menu"""
-        menu = QtWidgets.QMenu(self)
-        open_action = menu.addAction(f"&Open Detailed {type(entry).__name__} page")
-        # WeakPartialMethodSlot may not be needed, menus are transient
-        open_action.triggered.connect(partial(self.open_page, entry))
-        if isinstance(entry, Snapshot):
-            restore_page_action = menu.addAction("Inspect values")
-            restore_page_action.triggered.connect(partial(self.open_restore_page, entry))
-
-        return menu
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         try:


### PR DESCRIPTION
## Description
Add the details for a snapshot to the Snapshot Details page. This tells the user the title and creation time of the selected snapshot.

In addition, I made a paging system for the main application. This consists of a Page widget that the Snapshot Details page subclasses. This resulted in a lot of moving code to a new file, which is why the PR is so large.

## Motivation and Context

[SWAPPS-224](https://jira.slac.stanford.edu/browse/SWAPPS-224)

## How Has This Been Tested?

Interactively

![Screenshot 2025-05-20 at 10 11 27](https://github.com/user-attachments/assets/bed984ee-e017-488a-aeca-5bb14f743971)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran docs/pre-release-notes.sh and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate