### PR TITLE
ENH: Snapshot Comparison

### DIFF
--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -24,7 +24,8 @@ from superscore.widgets.window import Window
 # expose fixtures and helpers from other files in conftest so they will be gathered
 from .conftest_data import (linac_data, linac_with_comparison_snapshot,  # NOQA
                             parameter_with_readback, sample_database,
-                            setpoint_with_readback, simple_snapshot)
+                            setpoint_with_readback, simple_comparison_snapshot,
+                            simple_snapshot)
 
 
 @pytest.fixture(scope='function')
@@ -51,6 +52,11 @@ def parameter_with_readback_fixture() -> Parameter:
 @pytest.fixture(scope='function')
 def simple_snapshot_fixture() -> Collection:
     return simple_snapshot()
+
+
+@pytest.fixture(scope='function')
+def simple_comparison_snapshot_fixture() -> Collection:
+    return simple_comparison_snapshot()
 
 
 @pytest.fixture(scope='function')

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -872,6 +872,14 @@ def simple_snapshot() -> Collection:
     return snap
 
 
+def simple_comparison_snapshot() -> Collection:
+    snap = simple_snapshot()
+    snap.children.pop(0)
+    snap.children[0].data = 1
+    snap.children.append(Setpoint(pv_name="MY:NEW:ENUM"))
+    return snap
+
+
 def sample_database() -> Root:
     """
     A sample superscore database, including all the Entry types.

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -864,7 +864,7 @@ def parameter_with_readback() -> Parameter:
     return setpoint
 
 
-def simple_snapshot() -> Collection:
+def simple_snapshot() -> Snapshot:
     snap = Snapshot(description='various types', title='types collection')
     snap.children.append(Setpoint(pv_name="MY:FLOAT"))
     snap.children.append(Setpoint(pv_name="MY:INT"))
@@ -872,7 +872,7 @@ def simple_snapshot() -> Collection:
     return snap
 
 
-def simple_comparison_snapshot() -> Collection:
+def simple_comparison_snapshot() -> Snapshot:
     snap = simple_snapshot()
     snap.children.pop(0)
     snap.children[0].data = 1

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -20,6 +20,7 @@ from superscore.widgets.page.entry import (BaseParameterPage, CollectionPage,
 from superscore.widgets.page.restore import RestoreDialog, RestorePage
 from superscore.widgets.page.search import SearchPage
 from superscore.widgets.page.snapshot_comparison import SnapshotComparisonPage
+from superscore.widgets.snapshot_comparison_table import COMPARE_HEADER
 
 
 @pytest.fixture(scope='function')
@@ -318,7 +319,44 @@ def test_restore_dialog_remove_pv(
 
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
-def test_snapshot_comparison_page(
+def test_snapshot_comparison_page_set_main(
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot,
+):
+    page = SnapshotComparisonPage(
+        client=test_client,
+    )
+    page.set_main_snapshot(simple_snapshot_fixture)
+
+    # Check that the comparison table model is empty
+    assert page.comparison_table_model.rowCount() == 0
+
+    assert page.main_snapshot == simple_snapshot_fixture
+    assert page.main_snapshot_title_label.text() == simple_snapshot_fixture.title
+    assert page.main_snapshot_time_label.text() == simple_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_snapshot_comparison_page_set_comp(
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot,
+):
+    page = SnapshotComparisonPage(
+        client=test_client,
+    )
+    page.set_comparison_snapshot(simple_snapshot_fixture)
+
+    # Check that the comparison table model is empty
+    assert page.comparison_table_model.rowCount() == 0
+
+    # Check that the comparison snapshot is set correctly
+    assert page.comparison_snapshot == simple_snapshot_fixture
+    assert page.comp_snapshot_title_label.text() == simple_snapshot_fixture.title
+    assert page.comp_snapshot_time_label.text() == simple_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_snapshot_comparison_page_set_both(
     test_client: Client,
     simple_snapshot_fixture: Snapshot,
     simple_comparison_snapshot_fixture: Snapshot
@@ -330,15 +368,25 @@ def test_snapshot_comparison_page(
     page = SnapshotComparisonPage(
         client=test_client,
     )
-
     page.set_main_snapshot(simple_snapshot_fixture)
-    expected_time = simple_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
-    assert page.main_snapshot == simple_snapshot_fixture
-    assert page.main_snapshot_title_label.text() == simple_snapshot_fixture.title
-    assert page.main_snapshot_time_label.text() == expected_time
-
     page.set_comparison_snapshot(simple_comparison_snapshot_fixture)
-    expected_time = simple_comparison_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
-    assert page.comparison_snapshot == simple_comparison_snapshot_fixture
-    assert page.comp_snapshot_title_label.text() == simple_comparison_snapshot_fixture.title
-    assert page.comp_snapshot_time_label.text() == expected_time
+
+    compare_model = page.comparison_table_model
+    assert compare_model.rowCount() == 4
+
+    # Setup the data expected from the model
+    expected_data = [["MY:FLOAT", None, "--"],
+                     ["MY:INT", None, 1],
+                     ["MY:ENUM", None, None],
+                     ["MY:NEW:ENUM", "--", None]]
+
+    # Check that the model data matches the expected data
+    actual_data = []
+    for row in range(len(expected_data)):
+        actual_row = []
+        for column_header in (COMPARE_HEADER.PV, COMPARE_HEADER.SETPOINT, COMPARE_HEADER.COMPARE_SETPOINT):
+            col = column_header.value
+            index = compare_model.index(row, col)
+            actual_row.append(compare_model.data(index, QtCore.Qt.DisplayRole))
+        actual_data.append(actual_row)
+    assert actual_data == expected_data

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -19,6 +19,7 @@ from superscore.widgets.page.entry import (BaseParameterPage, CollectionPage,
                                            SetpointPage, SnapshotPage)
 from superscore.widgets.page.restore import RestoreDialog, RestorePage
 from superscore.widgets.page.search import SearchPage
+from superscore.widgets.page.snapshot_comparison import SnapshotComparisonPage
 
 
 @pytest.fixture(scope='function')
@@ -314,3 +315,30 @@ def test_restore_dialog_remove_pv(
     assert tableWidget.rowCount() == len(simple_snapshot_fixture.children) - 1
     items_left = [tableWidget.item(row, PV_COLUMN) for row in range(tableWidget.rowCount())]
     assert item_to_remove not in items_left
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_snapshot_comparison_page(
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot,
+    simple_comparison_snapshot_fixture: Snapshot
+):
+    # Setup the test backend and model
+    test_client.backend.save_entry(simple_snapshot_fixture)
+    test_client.backend.save_entry(simple_comparison_snapshot_fixture)
+
+    page = SnapshotComparisonPage(
+        client=test_client,
+    )
+
+    page.set_main_snapshot(simple_snapshot_fixture)
+    expected_time = simple_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+    assert page.main_snapshot == simple_snapshot_fixture
+    assert page.main_snapshot_title_label.text() == simple_snapshot_fixture.title
+    assert page.main_snapshot_time_label.text() == expected_time
+
+    page.set_comparison_snapshot(simple_comparison_snapshot_fixture)
+    expected_time = simple_comparison_snapshot_fixture.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+    assert page.comparison_snapshot == simple_comparison_snapshot_fixture
+    assert page.comp_snapshot_title_label.text() == simple_comparison_snapshot_fixture.title
+    assert page.comp_snapshot_time_label.text() == expected_time

--- a/superscore/widgets/page/page.py
+++ b/superscore/widgets/page/page.py
@@ -10,7 +10,7 @@ logger = getLogger(__name__)
 
 
 class Page(QtWidgets.QWidget):
-    def __init__(self, parent: QtWidgets.QWidget) -> None:
+    def __init__(self, parent: QtWidgets.QWidget = None) -> None:
         super().__init__(parent)
         self.pv_table_models: dict[UUID: PVTableModel] = {}
 

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -116,8 +116,3 @@ class SnapshotComparisonPage(Page):
         self.comp_snapshot_title_label.setText(snapshot.title)
         self.comp_snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
         self.comparison_table_model.set_comparison_snapshot(snapshot)
-
-    def update_comparison_table(self):
-        """Update the comparison table with the differences between the two snapshots."""
-        if self.main_snapshot is None or self.comparison_snapshot is None:
-            return

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -1,5 +1,5 @@
 import qtawesome as qta
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from superscore.model import Snapshot
 from superscore.widgets.page.page import Page
@@ -7,6 +7,8 @@ from superscore.widgets.page.page import Page
 
 class SnapshotComparisonPage(Page):
     """Page for comparing snapshots"""
+
+    remove_comparison_signal = QtCore.Signal()
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -50,7 +52,7 @@ class SnapshotComparisonPage(Page):
         # Add a label to show the comparison result
         comp_header_layout = QtWidgets.QHBoxLayout()
         comp_snapshot_label = QtWidgets.QLabel()
-        comp_snapshot_label.setText("Main Snapshot")
+        comp_snapshot_label.setText("Comparison Snapshot")
         comp_header_layout.addWidget(comp_snapshot_label)
 
         spacer_label3 = QtWidgets.QLabel()
@@ -73,14 +75,14 @@ class SnapshotComparisonPage(Page):
         comp_header_layout.addWidget(self.comp_snapshot_time_label)
         comp_header_layout.addSpacerItem(QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
         remove_button = QtWidgets.QPushButton(qta.icon("ei.remove"), "Remove Comparison", self)
-        remove_button.setEnabled(False)    # TODO: Remove the comparison
-        # remove_button.clicked.connect()
+        remove_button.clicked.connect(self.remove_comparison_signal.emit)
         comp_header_layout.addWidget(remove_button)
 
         snapshot_comparison_layout.addLayout(comp_header_layout)
 
         # Add a table to show the comparison result
         self.comparison_table = QtWidgets.QTableView()
+        snapshot_comparison_layout.addWidget(self.comparison_table)
 
     def set_main_snapshot(self, snapshot: Snapshot):
         """Set the main snapshot for comparison."""

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -13,7 +13,7 @@ class SnapshotComparisonPage(Page):
 
     remove_comparison_signal = QtCore.Signal()
 
-    def __init__(self, parent: QtWidgets.QWidget, client: Client):
+    def __init__(self, client: Client, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
         self.client = client
         self.main_snapshot = None

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -1,8 +1,11 @@
 import qtawesome as qta
 from qtpy import QtCore, QtWidgets
 
+from superscore.client import Client
 from superscore.model import Snapshot
 from superscore.widgets.page.page import Page
+from superscore.widgets.snapshot_comparison_table import \
+    SnapshotComparisonTableModel
 
 
 class SnapshotComparisonPage(Page):
@@ -10,8 +13,9 @@ class SnapshotComparisonPage(Page):
 
     remove_comparison_signal = QtCore.Signal()
 
-    def __init__(self, parent):
+    def __init__(self, parent: QtWidgets.QWidget, client: Client):
         super().__init__(parent)
+        self.client = client
         self.main_snapshot = None
         self.comparison_snapshot = None
 
@@ -81,7 +85,9 @@ class SnapshotComparisonPage(Page):
         snapshot_comparison_layout.addLayout(comp_header_layout)
 
         # Add a table to show the comparison result
+        self.comparison_table_model = SnapshotComparisonTableModel(self.client, self)
         self.comparison_table = QtWidgets.QTableView()
+        self.comparison_table.setModel(self.comparison_table_model)
         snapshot_comparison_layout.addWidget(self.comparison_table)
 
     def set_main_snapshot(self, snapshot: Snapshot):
@@ -89,12 +95,14 @@ class SnapshotComparisonPage(Page):
         self.main_snapshot = snapshot
         self.main_snapshot_title_label.setText(snapshot.title)
         self.main_snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
+        self.comparison_table_model.set_main_snapshot(snapshot)
 
     def set_comparison_snapshot(self, snapshot: Snapshot):
         """Set the comparison snapshot."""
         self.comparison_snapshot = snapshot
         self.comp_snapshot_title_label.setText(snapshot.title)
         self.comp_snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
+        self.comparison_table_model.set_comparison_snapshot(snapshot)
 
     def update_comparison_table(self):
         """Update the comparison table with the differences between the two snapshots."""

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -1,0 +1,100 @@
+import qtawesome as qta
+from qtpy import QtWidgets
+
+from superscore.model import Snapshot
+from superscore.widgets.page.page import Page
+
+
+class SnapshotComparisonPage(Page):
+    """Page for comparing snapshots"""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.main_snapshot = None
+        self.comparison_snapshot = None
+
+        self.setup_ui()
+
+    def setup_ui(self) -> None:
+        # Set up the layout
+        snapshot_comparison_layout = QtWidgets.QVBoxLayout()
+        self.setLayout(snapshot_comparison_layout)
+
+        # Add a label to show the comparison result
+        main_header_layout = QtWidgets.QHBoxLayout()
+        main_snapshot_label = QtWidgets.QLabel()
+        main_snapshot_label.setText("Main Snapshot")
+        main_header_layout.addWidget(main_snapshot_label)
+
+        spacer_label1 = QtWidgets.QLabel()
+        spacer_label1.setText("|")
+        spacer_label1.setStyleSheet("font: bold 18px")
+        main_header_layout.addWidget(spacer_label1)
+
+        self.main_snapshot_title_label = QtWidgets.QLabel()
+        main_header_layout.addWidget(self.main_snapshot_title_label)
+
+        spacer_label2 = QtWidgets.QLabel()
+        spacer_label2.setText("|")
+        spacer_label2.setStyleSheet("font: bold 18px")
+        main_header_layout.addWidget(spacer_label2)
+
+        self.main_snapshot_time_label = QtWidgets.QLabel()
+        self.main_snapshot_time_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Preferred,)
+        main_header_layout.addWidget(self.main_snapshot_time_label)
+
+        snapshot_comparison_layout.addLayout(main_header_layout)
+
+        # Add a label to show the comparison result
+        comp_header_layout = QtWidgets.QHBoxLayout()
+        comp_snapshot_label = QtWidgets.QLabel()
+        comp_snapshot_label.setText("Main Snapshot")
+        comp_header_layout.addWidget(comp_snapshot_label)
+
+        spacer_label3 = QtWidgets.QLabel()
+        spacer_label3.setText("|")
+        spacer_label3.setStyleSheet("font: bold 18px")
+        comp_header_layout.addWidget(spacer_label3)
+
+        self.comp_snapshot_title_label = QtWidgets.QLabel()
+        comp_header_layout.addWidget(self.comp_snapshot_title_label)
+
+        spacer_label4 = QtWidgets.QLabel()
+        spacer_label4.setText("|")
+        spacer_label4.setStyleSheet("font: bold 18px")
+        comp_header_layout.addWidget(spacer_label4)
+
+        self.comp_snapshot_time_label = QtWidgets.QLabel()
+        self.comp_snapshot_time_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Preferred,)
+        comp_header_layout.addWidget(self.comp_snapshot_time_label)
+        comp_header_layout.addSpacerItem(QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
+        remove_button = QtWidgets.QPushButton(qta.icon("ei.remove"), "Remove Comparison", self)
+        remove_button.setEnabled(False)    # TODO: Remove the comparison
+        # remove_button.clicked.connect()
+        comp_header_layout.addWidget(remove_button)
+
+        snapshot_comparison_layout.addLayout(comp_header_layout)
+
+        # Add a table to show the comparison result
+        self.comparison_table = QtWidgets.QTableView()
+
+    def set_main_snapshot(self, snapshot: Snapshot):
+        """Set the main snapshot for comparison."""
+        self.main_snapshot = snapshot
+        self.main_snapshot_title_label.setText(snapshot.title)
+        self.main_snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
+
+    def set_comparison_snapshot(self, snapshot: Snapshot):
+        """Set the comparison snapshot."""
+        self.comparison_snapshot = snapshot
+        self.comp_snapshot_title_label.setText(snapshot.title)
+        self.comp_snapshot_time_label.setText(snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S"))
+
+    def update_comparison_table(self):
+        """Update the comparison table with the differences between the two snapshots."""
+        if self.main_snapshot is None or self.comparison_snapshot is None:
+            return

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -4,8 +4,8 @@ from qtpy import QtCore, QtWidgets
 from superscore.client import Client
 from superscore.model import Snapshot
 from superscore.widgets.page.page import Page
-from superscore.widgets.snapshot_comparison_table import \
-    SnapshotComparisonTableModel
+from superscore.widgets.snapshot_comparison_table import (
+    COMPARE_HEADER, SnapshotComparisonTableModel)
 
 
 class SnapshotComparisonPage(Page):
@@ -88,6 +88,14 @@ class SnapshotComparisonPage(Page):
         self.comparison_table_model = SnapshotComparisonTableModel(self.client, self)
         self.comparison_table = QtWidgets.QTableView()
         self.comparison_table.setModel(self.comparison_table_model)
+        self.comparison_table.verticalHeader().hide()
+        header_view = self.comparison_table.horizontalHeader()
+        header_view.setSectionResizeMode(header_view.Stretch)
+        header_view.setSectionResizeMode(COMPARE_HEADER.CHECKBOX.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(COMPARE_HEADER.SEVERITY.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(COMPARE_HEADER.COMPARE_SEVERITY.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(COMPARE_HEADER.DEVICE.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(COMPARE_HEADER.PV.value, header_view.ResizeToContents)
         snapshot_comparison_layout.addWidget(self.comparison_table)
 
     def set_main_snapshot(self, snapshot: Snapshot):

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -24,65 +24,70 @@ class SnapshotComparisonPage(Page):
     def setup_ui(self) -> None:
         # Set up the layout
         snapshot_comparison_layout = QtWidgets.QVBoxLayout()
+        snapshot_comparison_layout.setContentsMargins(0, 11, 0, 0)
         self.setLayout(snapshot_comparison_layout)
 
-        # Add a label to show the comparison result
-        main_header_layout = QtWidgets.QHBoxLayout()
+        # Set up the header
+        header_layout = QtWidgets.QGridLayout()
+        snapshot_comparison_layout.addLayout(header_layout)
+
+        back_button = QtWidgets.QPushButton()
+        back_button.setIcon(qta.icon("ph.arrow-left"))
+        back_button.setIconSize(QtCore.QSize(24, 24))
+        back_button.setStyleSheet("border: none")
+        back_button.clicked.connect(self.remove_comparison_signal.emit)
+        header_layout.addWidget(back_button, 0, 0)
+
         main_snapshot_label = QtWidgets.QLabel()
         main_snapshot_label.setText("Main Snapshot")
-        main_header_layout.addWidget(main_snapshot_label)
+        header_layout.addWidget(main_snapshot_label, 0, 1)
 
         spacer_label1 = QtWidgets.QLabel()
         spacer_label1.setText("|")
         spacer_label1.setStyleSheet("font: bold 18px")
-        main_header_layout.addWidget(spacer_label1)
+        header_layout.addWidget(spacer_label1, 0, 2)
 
         self.main_snapshot_title_label = QtWidgets.QLabel()
-        main_header_layout.addWidget(self.main_snapshot_title_label)
+        header_layout.addWidget(self.main_snapshot_title_label, 0, 3)
 
         spacer_label2 = QtWidgets.QLabel()
         spacer_label2.setText("|")
         spacer_label2.setStyleSheet("font: bold 18px")
-        main_header_layout.addWidget(spacer_label2)
+        header_layout.addWidget(spacer_label2, 0, 4)
 
         self.main_snapshot_time_label = QtWidgets.QLabel()
         self.main_snapshot_time_label.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding,
             QtWidgets.QSizePolicy.Preferred,)
-        main_header_layout.addWidget(self.main_snapshot_time_label)
+        header_layout.addWidget(self.main_snapshot_time_label, 0, 5)
 
-        snapshot_comparison_layout.addLayout(main_header_layout)
-
-        # Add a label to show the comparison result
-        comp_header_layout = QtWidgets.QHBoxLayout()
+        # Second row of the header
         comp_snapshot_label = QtWidgets.QLabel()
         comp_snapshot_label.setText("Comparison Snapshot")
-        comp_header_layout.addWidget(comp_snapshot_label)
+        header_layout.addWidget(comp_snapshot_label, 1, 1)
 
         spacer_label3 = QtWidgets.QLabel()
         spacer_label3.setText("|")
         spacer_label3.setStyleSheet("font: bold 18px")
-        comp_header_layout.addWidget(spacer_label3)
+        header_layout.addWidget(spacer_label3, 1, 2)
 
         self.comp_snapshot_title_label = QtWidgets.QLabel()
-        comp_header_layout.addWidget(self.comp_snapshot_title_label)
+        header_layout.addWidget(self.comp_snapshot_title_label, 1, 3)
 
         spacer_label4 = QtWidgets.QLabel()
         spacer_label4.setText("|")
         spacer_label4.setStyleSheet("font: bold 18px")
-        comp_header_layout.addWidget(spacer_label4)
+        header_layout.addWidget(spacer_label4, 1, 4)
 
         self.comp_snapshot_time_label = QtWidgets.QLabel()
         self.comp_snapshot_time_label.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding,
             QtWidgets.QSizePolicy.Preferred,)
-        comp_header_layout.addWidget(self.comp_snapshot_time_label)
-        comp_header_layout.addSpacerItem(QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
+        header_layout.addWidget(self.comp_snapshot_time_label, 1, 5)
+
         remove_button = QtWidgets.QPushButton(qta.icon("ei.remove"), "Remove Comparison", self)
         remove_button.clicked.connect(self.remove_comparison_signal.emit)
-        comp_header_layout.addWidget(remove_button)
-
-        snapshot_comparison_layout.addLayout(comp_header_layout)
+        header_layout.addWidget(remove_button, 1, 6)
 
         # Add a table to show the comparison result
         self.comparison_table_model = SnapshotComparisonTableModel(self.client, self)

--- a/superscore/widgets/snapshot_comparison_table.py
+++ b/superscore/widgets/snapshot_comparison_table.py
@@ -156,6 +156,7 @@ class SnapshotComparisonTableModel(QtCore.QAbstractTableModel):
         return None
 
     def setData(self, index: QtCore.QModelIndex, value: Any, role: QtCore.Qt.ItemDataRole) -> bool:
+        """Set the data for a given index. Only checkboxes are editable."""
         column = COMPARE_HEADER(index.column())
         if role == QtCore.Qt.CheckStateRole and column == COMPARE_HEADER.CHECKBOX:
             if value == QtCore.Qt.Checked:

--- a/superscore/widgets/snapshot_comparison_table.py
+++ b/superscore/widgets/snapshot_comparison_table.py
@@ -1,9 +1,15 @@
 from enum import Enum, auto
+from typing import Any
 from uuid import UUID
 
-from qtpy import QtCore
+import numpy as np
+from qtpy import QtCore, QtGui
 
-from superscore.model import Readback, Setpoint, Snapshot
+import superscore.color
+from superscore.model import Readback, Setpoint
+from superscore.widgets import SEVERITY_ICONS
+
+NO_DATA = "--"
 
 
 class COMPARE_HEADER(Enum):
@@ -20,11 +26,15 @@ class COMPARE_HEADER(Enum):
     def display_string(self) -> str:
         return self._strings[self]
 
+    def is_compare_column(self) -> bool:
+        return self in (self.COMPARE_SEVERITY, self.COMPARE_SETPOINT,
+                        self.COMPARE_READBACK)
+
 
 COMPARE_HEADER._strings = {
     COMPARE_HEADER.CHECKBOX: "",
-    COMPARE_HEADER.SEVERITY: "",
-    COMPARE_HEADER.COMPARE_SEVERITY: "",
+    COMPARE_HEADER.SEVERITY: "Severity",
+    COMPARE_HEADER.COMPARE_SEVERITY: "Comparison Severity",
     COMPARE_HEADER.DEVICE: "Device",
     COMPARE_HEADER.PV: "PV Name",
     COMPARE_HEADER.SETPOINT: "Saved Value",
@@ -34,17 +44,18 @@ COMPARE_HEADER._strings = {
 }
 
 
-class SnapshotComparisonTableModel(QtCore.AbstractTableModel):
+class SnapshotComparisonTableModel(QtCore.QAbstractTableModel):
     """
     A table model for representing PV data within a Snapshot. Includes live data and checkboxes
     for selecting rows.
     """
-    def __init__(self, main_snapshot: Snapshot, client, parent=None):
+    def __init__(self, client, parent=None):
         super().__init__(parent)
         self.client = client
         self._data = []
+        self._checked = set()
 
-        self.main_snapshot = main_snapshot
+        self.main_snapshot = None
         self.comparison_snapshot = None
 
     def rowCount(self, parent=None):
@@ -62,9 +73,106 @@ class SnapshotComparisonTableModel(QtCore.AbstractTableModel):
         if orientation == QtCore.Qt.Horizontal:
             if role == QtCore.Qt.DisplayRole:
                 return COMPARE_HEADER(section).display_string()
+        return None
 
-    def _collate_pvs(self) -> None:
+    def flags(self, index) -> QtCore.Qt.ItemFlags:
+        column = COMPARE_HEADER(index.column())
+        if column == COMPARE_HEADER.CHECKBOX:
+            return QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEnabled
+        else:
+            return super().flags(index)
+
+    def data(
+        self,
+        index: QtCore.QModelIndex,
+        role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ):
+        if role == QtCore.Qt.TextAlignmentRole and index.data() == NO_DATA:
+            return QtCore.Qt.AlignCenter
+
+        column = COMPARE_HEADER(index.column())
+        is_compare_column = column.is_compare_column()
+
+        # Get the entry and compare objects, swapping them if necessary
+        entry, compare = self._data[index.row()]
+        if is_compare_column:
+            entry, compare = compare, entry
+
+        # If there is no entry data, return a default value
+        if entry is None:
+            return NO_DATA if role == QtCore.Qt.DisplayRole else None
+        elif role == QtCore.Qt.CheckStateRole:
+            if column == COMPARE_HEADER.CHECKBOX:
+                return QtCore.Qt.Checked if index.row() in self._checked else QtCore.Qt.Unchecked
+        elif role == QtCore.Qt.BackgroundRole:
+            if compare is None:
+                return None
+            elif column == COMPARE_HEADER.COMPARE_SETPOINT:
+                try:
+                    is_close = np.isclose(entry.data, compare.data)
+                except TypeError:
+                    is_close = entry.data == compare.data
+                if compare.data is not None and not is_close:
+                    return QtGui.QColor(superscore.color.RED)
+            elif column == COMPARE_HEADER.COMPARE_READBACK:
+                try:
+                    is_close = np.isclose(entry.readback.data, compare.readback.data)
+                except TypeError:
+                    is_close = entry.readback.data == compare.readback.data
+                except AttributeError:
+                    return None
+                if compare.readback.data is not None and not is_close:
+                    return QtGui.QColor(superscore.color.RED)
+        elif role == QtCore.Qt.ToolTipRole:
+            try:
+                return entry.pv_name
+            except AttributeError:
+                return compare.pv_name
+        elif role == QtCore.Qt.DecorationRole:
+            if column in (COMPARE_HEADER.SEVERITY, COMPARE_HEADER.COMPARE_SEVERITY):
+                icon = SEVERITY_ICONS[entry.severity]
+                if icon is None:
+                    icon = SEVERITY_ICONS[entry.status]
+                return icon
+        elif role == QtCore.Qt.DisplayRole:
+            if column == COMPARE_HEADER.DEVICE:
+                # TODO: figure out how to represent a device
+                return NO_DATA
+            elif column == COMPARE_HEADER.PV:
+                return entry.pv_name
+            elif column in (COMPARE_HEADER.SETPOINT, COMPARE_HEADER.COMPARE_SETPOINT):
+                return entry.data
+            elif column in (COMPARE_HEADER.READBACK, COMPARE_HEADER.COMPARE_READBACK):
+                try:
+                    return entry.readback.data
+                except AttributeError:
+                    return NO_DATA
+
+        # Default case
+        return None
+
+    def setData(self, index: QtCore.QModelIndex, value: Any, role: QtCore.Qt.ItemDataRole) -> bool:
+        column = COMPARE_HEADER(index.column())
+        if role == QtCore.Qt.CheckStateRole and column == COMPARE_HEADER.CHECKBOX:
+            if value == QtCore.Qt.Checked:
+                self._checked.add(index.row())
+            elif value == QtCore.Qt.Unchecked:
+                self._checked.remove(index.row())
+            self.dataChanged.emit(index, index)
+        return True
+
+    def ready_for_comparison(self) -> bool:
+        """Check if the model is ready for comparison."""
+        has_main = self.main_snapshot is not None
+        has_comp = self.comparison_snapshot is not None
+        main_is_comp = self.main_snapshot == self.comparison_snapshot
+        return has_main and has_comp and not main_is_comp
+
+    def collate_pvs(self) -> None:
         """Get all PVs for the snapshots to be compared."""
+        if not self.ready_for_comparison():
+            return
+
         self.beginResetModel()
         self._data = []
         # for each PV in primary snapshot, find partner in secondary snapshot
@@ -100,9 +208,9 @@ class SnapshotComparisonTableModel(QtCore.AbstractTableModel):
     def set_main_snapshot(self, main_snapshot: UUID) -> None:
         """Set the main snapshot and update the model."""
         self.main_snapshot = main_snapshot
-        self._collate_pvs()
+        self.collate_pvs()
 
     def set_comparison_snapshot(self, comparison_snapshot: UUID) -> None:
         """Set the comparison snapshot and update the model."""
         self.comparison_snapshot = comparison_snapshot
-        self._collate_pvs()
+        self.collate_pvs()

--- a/superscore/widgets/snapshot_comparison_table.py
+++ b/superscore/widgets/snapshot_comparison_table.py
@@ -1,0 +1,108 @@
+from enum import Enum, auto
+from uuid import UUID
+
+from qtpy import QtCore
+
+from superscore.model import Readback, Setpoint, Snapshot
+
+
+class COMPARE_HEADER(Enum):
+    CHECKBOX = 0
+    SEVERITY = auto()
+    COMPARE_SEVERITY = auto()
+    DEVICE = auto()
+    PV = auto()
+    SETPOINT = auto()
+    COMPARE_SETPOINT = auto()
+    READBACK = auto()
+    COMPARE_READBACK = auto()
+
+    def display_string(self) -> str:
+        return self._strings[self]
+
+
+COMPARE_HEADER._strings = {
+    COMPARE_HEADER.CHECKBOX: "",
+    COMPARE_HEADER.SEVERITY: "",
+    COMPARE_HEADER.COMPARE_SEVERITY: "",
+    COMPARE_HEADER.DEVICE: "Device",
+    COMPARE_HEADER.PV: "PV Name",
+    COMPARE_HEADER.SETPOINT: "Saved Value",
+    COMPARE_HEADER.COMPARE_SETPOINT: "Comparison Value",
+    COMPARE_HEADER.READBACK: "Saved Readback",
+    COMPARE_HEADER.COMPARE_READBACK: "Comparison Readback",
+}
+
+
+class SnapshotComparisonTableModel(QtCore.AbstractTableModel):
+    """
+    A table model for representing PV data within a Snapshot. Includes live data and checkboxes
+    for selecting rows.
+    """
+    def __init__(self, main_snapshot: Snapshot, client, parent=None):
+        super().__init__(parent)
+        self.client = client
+        self._data = []
+
+        self.main_snapshot = main_snapshot
+        self.comparison_snapshot = None
+
+    def rowCount(self, parent=None):
+        return len(self._data)
+
+    def columnCount(self, parent=None):
+        return len(COMPARE_HEADER)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ) -> str:
+        if orientation == QtCore.Qt.Horizontal:
+            if role == QtCore.Qt.DisplayRole:
+                return COMPARE_HEADER(section).display_string()
+
+    def _collate_pvs(self) -> None:
+        """Get all PVs for the snapshots to be compared."""
+        self.beginResetModel()
+        self._data = []
+        # for each PV in primary snapshot, find partner in secondary snapshot
+        pvs = self.client.search(
+            ("entry_type", "eq", (Setpoint, Readback)),
+            ("ancestor", "eq", self.main_snapshot.uuid),
+        )
+        seen = set()
+        for primary in tuple(pvs):
+            secondary_generator = self.client.search(
+                ("pv_name", "eq", primary.pv_name),
+                ("entry_type", "eq", type(primary)),
+                ("ancestor", "eq", self.comparison_snapshot.uuid),
+            )
+            try:
+                secondary = tuple(secondary_generator)[0]  # assumes at most one match
+            except IndexError:
+                secondary = None
+
+            self._data.append((primary, secondary))
+            if secondary:
+                seen.add(secondary.uuid)
+        # for each PV in secondary with no partner in primary, add row with 'None' partner
+        pvs = self.client.search(
+            ("entry_type", "eq", (Setpoint, Readback)),
+            ("ancestor", "eq", self.comparison_snapshot.uuid),
+        )
+        for secondary in pvs:
+            if secondary.uuid not in seen:
+                self._data.append((None, secondary))
+        self.endResetModel()
+
+    def set_main_snapshot(self, main_snapshot: UUID) -> None:
+        """Set the main snapshot and update the model."""
+        self.main_snapshot = main_snapshot
+        self._collate_pvs()
+
+    def set_comparison_snapshot(self, comparison_snapshot: UUID) -> None:
+        """Set the comparison snapshot and update the model."""
+        self.comparison_snapshot = comparison_snapshot
+        self._collate_pvs()

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -116,7 +116,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
     def init_comparison_page(self) -> SnapshotComparisonPage:
         """Initialize the snapshot comparison page so it can be opened later."""
         comparison_page = SnapshotComparisonPage(self.client, self)
-        comparison_page.remove_comparison_signal.connect(self.open_snapshot_details)
+        comparison_page.remove_comparison_signal.connect(self.open_snapshot)
 
         return comparison_page
 
@@ -167,9 +167,8 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.main_content_stack.setCurrentWidget(self.view_snapshot_page)
             self.navigation_panel.set_nav_button_selected(self.navigation_panel.view_snapshots_button)
 
-    @QtCore.Slot()
     @QtCore.Slot(QtCore.QModelIndex)
-    def open_snapshot_index(self, index: QtCore.QModelIndex = None) -> None:
+    def open_snapshot_index(self, index: QtCore.QModelIndex) -> None:
         """
         Opens the snapshot stored at the selected index. A widget representing the
         snapshot is created if necessary and set as the current view in the stack.
@@ -177,17 +176,19 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         Args:
             index (QtCore.Qt.QModelIndex): table index of the snapshot to open
         """
-        if isinstance(index, QtCore.QModelIndex):
-            if not index.isValid():
-                logger.warning("Invalid index passed to open_snapshot_details")
-                return
+        if not index.isValid():
+            logger.warning("Invalid index passed to open_snapshot_details")
+            return
 
-            # Set new_snapshot in the details page
-            new_snapshot = self.snapshot_table.model().index_to_snapshot(index)
+        # Set new_snapshot in the details page
+        new_snapshot = self.snapshot_table.model().index_to_snapshot(index)
         self.open_snapshot(new_snapshot)
 
-    def open_snapshot(self, snapshot: Snapshot) -> None:
-        self.snapshot_details_page.set_snapshot(snapshot)
+    @QtCore.Slot()
+    @QtCore.Slot(Snapshot)
+    def open_snapshot(self, snapshot: Snapshot = None) -> None:
+        if isinstance(snapshot, Snapshot):
+            self.snapshot_details_page.set_snapshot(snapshot)
         self.main_content_stack.setCurrentWidget(self.snapshot_details_page)
 
     def take_snapshot(self) -> Optional[Snapshot]:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -115,7 +115,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
 
     def init_comparison_page(self) -> SnapshotComparisonPage:
         """Initialize the snapshot comparison page so it can be opened later."""
-        comparison_page = SnapshotComparisonPage(self, self.client)
+        comparison_page = SnapshotComparisonPage(self.client, self)
         comparison_page.remove_comparison_signal.connect(self.open_snapshot_details)
 
         return comparison_page

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -103,19 +103,19 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         view_snapshot_layout.addWidget(self.snapshot_table)
         return view_snapshot_page
 
-    def init_snapshot_details_page(self) -> Page:
+    def init_snapshot_details_page(self) -> SnapshotDetailsPage:
         """Initialize the snapshot details page with the first snapshot in the snapshot_model."""
         temp_index = self.snapshot_table.model().index(0, 0)
         first_snapshot = self.snapshot_table.model().index_to_snapshot(temp_index)
         snapshot_details_page = SnapshotDetailsPage(self, self.client, first_snapshot)
         snapshot_details_page.back_to_main_signal.connect(self.open_view_snapshot_page)
-        self.snapshot_details_page.comparison_signal.connect(self.open_comparison_page)
+        snapshot_details_page.comparison_signal.connect(self.open_comparison_page)
 
         return snapshot_details_page
 
-    def init_comparison_page(self) -> QtWidgets.QWidget:
+    def init_comparison_page(self) -> SnapshotComparisonPage:
         """Initialize the snapshot comparison page so it can be opened later."""
-        comparison_page = SnapshotComparisonPage(self)
+        comparison_page = SnapshotComparisonPage(self, self.client)
         comparison_page.remove_comparison_signal.connect(self.open_snapshot_details)
 
         return comparison_page
@@ -167,8 +167,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.main_content_stack.setCurrentWidget(self.view_snapshot_page)
             self.navigation_panel.set_nav_button_selected(self.navigation_panel.view_snapshots_button)
 
+    @QtCore.Slot()
     @QtCore.Slot(QtCore.QModelIndex)
-    def open_snapshot_index(self, index: QtCore.Qt.QModelIndex) -> None:
+    def open_snapshot_index(self, index: QtCore.QModelIndex = None) -> None:
         """
         Opens the snapshot stored at the selected index. A widget representing the
         snapshot is created if necessary and set as the current view in the stack.
@@ -176,11 +177,14 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         Args:
             index (QtCore.Qt.QModelIndex): table index of the snapshot to open
         """
-        if not index.isValid():
-            logger.warning("Invalid index passed to open_snapshot_index")
-            return
-        snapshot = self.snapshot_table.model()._data[index.row()]
-        self.open_snapshot(snapshot)
+        if isinstance(index, QtCore.QModelIndex):
+            if not index.isValid():
+                logger.warning("Invalid index passed to open_snapshot_details")
+                return
+
+            # Set new_snapshot in the details page
+            new_snapshot = self.snapshot_table.model()._data[index.row()]
+        self.open_snapshot(new_snapshot)
 
     def open_snapshot(self, snapshot: Snapshot) -> None:
         self.snapshot_details_page.set_snapshot(snapshot)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -183,7 +183,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
                 return
 
             # Set new_snapshot in the details page
-            new_snapshot = self.snapshot_table.model()._data[index.row()]
+            new_snapshot = self.snapshot_table.model().index_to_snapshot(index)
         self.open_snapshot(new_snapshot)
 
     def open_snapshot(self, snapshot: Snapshot) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Allow users to select a snapshot to compare the main snapshot to. The comparison table shows the differences between the 2 snapshots, and highlights the differences in values.

## Motivation and Context
Users should be able to compare 2 existing snapshots as requested in Jira ticket [SWAPPS-229](https://jira.slac.stanford.edu/browse/SWAPPS-229)

## How Has This Been Tested?
Interactively & added tests to test suite

## Where Has This Been Documented?
This PR

### Snapshot Selection Dialog
<img width="562" alt="Screenshot 2025-05-23 at 12 31 03" src="https://github.com/user-attachments/assets/1d8c1751-97ee-4355-96a1-844723ebcbb9" />

### Snapshot Comparison Table
<img width="1512" alt="Screenshot 2025-05-23 at 15 28 55" src="https://github.com/user-attachments/assets/b1915711-6824-4008-a0cf-0814c7fdbf2a" />



## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
