### PR TITLE
MNT: set default window area to 50% of primary screen

### DIFF
--- a/superscore/bin/ui_main.py
+++ b/superscore/bin/ui_main.py
@@ -11,8 +11,8 @@ from qtpy.QtWidgets import QApplication
 from superscore.client import Client
 from superscore.widgets.window import Window
 
-MAX_DEFAULT_WIDTH = 1400
-MAX_DEFAULT_HEIGHT = 800
+MAX_DEFAULT_WIDTH = 1920
+MAX_DEFAULT_HEIGHT = 1080
 
 
 def main(cfg_path: Optional[str] = None):
@@ -26,8 +26,8 @@ def main(cfg_path: Optional[str] = None):
     primary_screen = app.screens()[0]
     screen_width = primary_screen.geometry().width()
     screen_height = primary_screen.geometry().height()
-    width = min(int(screen_width*.5), MAX_DEFAULT_WIDTH)
-    height = min(int(screen_height*.5), MAX_DEFAULT_HEIGHT)
+    width = min(int(screen_width*.7), MAX_DEFAULT_WIDTH)
+    height = min(int(screen_height*.7), MAX_DEFAULT_HEIGHT)
     # move window rather creating a QRect because we want to include the frame geometry
     main_window.setGeometry(0, 0, width, height)
     center = primary_screen.geometry().center()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Upon opening the UI, the main window's height and width are set to the smaller of the defaults and half of the screen's height and width. This makes the window take up 50% of the primary screen's area. The current window size is set as the default, to prevent the window from being oversized in the case of multiple monitors being reported as one combined screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually / interactively

## Screenshots (if appropriate):
The current size is the smallest window below (red), while the largest window (orange) is the new maximum initial size of 1920x1080, and the middle window (green) is 50% of my primary desktop screen.
![Screenshot 2025-06-05 at 11 30 23](https://github.com/user-attachments/assets/166dcd13-bebe-4cf7-bd3f-bad8748af415)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
