### PR TITLE
GUI: simplify and improve editing widgets' sizing in NameDescTagsWidget

### DIFF
--- a/superscore/ui/name_desc_tags_widget.ui
+++ b/superscore/ui/name_desc_tags_widget.ui
@@ -57,7 +57,7 @@
       <item>
        <widget class="QLineEdit" name="name_edit">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -67,41 +67,6 @@
           <width>100</width>
           <height>0</height>
          </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="extra_text_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -15,7 +15,6 @@ from superscore.qt_helpers import QDataclassBridge
 from superscore.type_hints import AnyDataclass, OpenPageSlot, TagDef
 from superscore.utils import SUPERSCORE_SOURCE_PATH
 from superscore.widgets import TagsWidget, get_window
-from superscore.widgets.manip_helpers import match_line_edit_text_width
 
 
 class Display(DesignerDisplay):
@@ -78,10 +77,8 @@ class NameMixin:
         load_name = self.bridge.title.get() or ''
         self.last_name = load_name
         self.name_edit.setText(load_name)
-        self.on_text_changed(load_name)
         # Set up the saving/loading
         self.name_edit.textEdited.connect(self.update_saved_name)
-        self.name_edit.textChanged.connect(self.on_text_changed)
         self.bridge.title.changed_value.connect(self.apply_new_name)
 
     def update_saved_name(self, name: str) -> None:
@@ -100,9 +97,6 @@ class NameMixin:
         if text != self.last_name:
             self.name_edit.setText(text)
 
-    def on_text_changed(self, text: str):
-        match_line_edit_text_width(self.name_edit, text=text)
-
 
 class NameDescTagsWidget(Display, NameMixin, DataWidget):
     """
@@ -110,8 +104,6 @@ class NameDescTagsWidget(Display, NameMixin, DataWidget):
 
     Any of these will be automatically disabled if the data source is missing
     the corresponding field.
-
-    As a convenience, this also holds an "extra_text_label" QLabel for general use.
     """
     filename = 'name_desc_tags_widget.ui'
 
@@ -120,7 +112,6 @@ class NameDescTagsWidget(Display, NameMixin, DataWidget):
     desc_edit: QtWidgets.QPlainTextEdit
     desc_frame: QtWidgets.QFrame
     tags_widget: TagsWidget
-    extra_text_label: QtWidgets.QLabel
 
     def __init__(self, data: AnyDataclass, **kwargs):
 

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -148,7 +148,6 @@ class NameDescTagsWidget(Display, NameMixin, DataWidget):
         # Setup the saving/loading
         self.desc_edit.textChanged.connect(self.update_saved_desc)
         self.bridge.description.changed_value.connect(self.apply_new_desc)
-        self.desc_edit.textChanged.connect(self.update_text_height)
 
     def update_saved_desc(self) -> None:
         """
@@ -163,33 +162,6 @@ class NameDescTagsWidget(Display, NameMixin, DataWidget):
         """
         if desc != self.last_desc:
             self.desc_edit.setPlainText(desc)
-
-    def showEvent(self, *args, **kwargs) -> None:
-        """
-        Override showEvent to update the desc height when we are shown.
-        """
-        try:
-            self.update_text_height()
-        except AttributeError:
-            pass
-        return super().showEvent(*args, **kwargs)
-
-    def resizeEvent(self, *args, **kwargs) -> None:
-        """
-        Override resizeEvent to update the desc height when we resize.
-        """
-        try:
-            self.update_text_height()
-        except AttributeError:
-            pass
-        return super().resizeEvent(*args, **kwargs)
-
-    def update_text_height(self) -> None:
-        """
-        When the user edits the desc, make the text box the correct height.
-        """
-        line_count = max(self.desc_edit.document().size().toSize().height(), 1)
-        self.desc_edit.setFixedHeight(line_count * 13 + 12)
 
     def init_tags(self, tag_groups: TagDef) -> None:
         """

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -218,6 +218,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         buttonBox.accepted.connect(metadata_dialog.accept)
         buttonBox.rejected.connect(metadata_dialog.reject)
         metadata_dialog.setLayout(layout)
+        metadata_dialog.resize(558, 254)
         return metadata_dialog
 
     @QtCore.Slot(Snapshot, Snapshot)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Remove logic that sets name `QLineEdit` fixed width whenever text changes
* Remove unused `extra_text_label` and unnecessary spacer
* Remove overriding `showEvent` and `resizeEvent` methods that lock description text edit height to the existing text
* Resize dialog window to expand horizontal space, which is more natural for text
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original looks ugly and acts wonky
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
👁️ Look at it 👁️ 
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
☝️ 
## Screenshots (if appropriate):
Original
![Screenshot 2025-06-05 at 14 04 56](https://github.com/user-attachments/assets/c13de542-247e-4be7-a36b-dffc61dcfd27)

Updated
![Screenshot 2025-06-05 at 15 47 08](https://github.com/user-attachments/assets/16c22d0e-b32e-49a1-92bc-8817a6831f35)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
