### PR TITLE
BLD: swap PyQt5 req for pyside6

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - aioca
     - apischema
     - pcdsutils
-    - pyqt
+    - pyside6
     - python-dateutil
     - qtawesome
     - qtpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ file = "dev-requirements.txt"
 file = "docs-requirements.txt"
 
 [tool.pytest.ini_options]
-addopts = "--cov=. --no-cov-on-fail --asyncio-mode=auto"
+addopts = "--cov=superscore --no-cov-on-fail --asyncio-mode=auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 aioca
 apischema
 pcdsutils
-PyQt5
+pyside6
 python-dateutil
 qtawesome
 qtpy

--- a/superscore/tests/test_widgets.py
+++ b/superscore/tests/test_widgets.py
@@ -62,7 +62,7 @@ def test_tags_widget(qtbot):
     assert len(chip.tags) == 0
 
     selection_model = chip.editor.choice_list.selectionModel()
-    Select = selection_model.Select
+    Select = selection_model.SelectionFlag.Select
     index = selection_model.model().index(0, 0)
     selection_model.select(index, Select)
     index = selection_model.model().index(1, 0)
@@ -71,7 +71,7 @@ def test_tags_widget(qtbot):
     assert 0 in chip.tags
     assert 1 in chip.tags
 
-    Deselect = selection_model.Deselect
+    Deselect = selection_model.SelectionFlag.Deselect
     selection_model.select(index, Deselect)
     assert len(chip.tags) == 1
     assert 0 in chip.tags

--- a/superscore/widgets/page/diff.py
+++ b/superscore/widgets/page/diff.py
@@ -4,7 +4,6 @@ from functools import partial
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from PyQt5.QtGui import QCloseEvent
 from qtpy import QtCore, QtGui, QtWidgets
 
 from superscore.compare import DiffType, EntryDiff
@@ -20,9 +19,9 @@ logger = logging.getLogger(__name__)
 
 
 DIFF_COLOR_MAP = {
-    DiffType.DELETED: QtGui.QColor(255, 0, 0, alpha=100),
-    DiffType.MODIFIED: QtGui.QColor(255, 255, 0, alpha=100),
-    DiffType.ADDED: QtGui.QColor(0, 255, 0, alpha=100),
+    DiffType.DELETED: QtGui.QColor(255, 0, 0, a=100),
+    DiffType.MODIFIED: QtGui.QColor(255, 255, 0, a=100),
+    DiffType.ADDED: QtGui.QColor(0, 255, 0, a=100),
     None: None,  # the no modification case, do not change background color
 }
 
@@ -409,7 +408,7 @@ class DiffPage(Display, QtWidgets.QWidget, WindowLinker):
                 model._diff = diff
                 model._linked_uuids = self._linked_uuids
 
-    def closeEvent(self, a0: QCloseEvent) -> None:
+    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
         for side in Side:
             self.widget_map[side]['pv'].close()
         return super().closeEvent(a0)

--- a/superscore/widgets/page/pv_browser.py
+++ b/superscore/widgets/page/pv_browser.py
@@ -50,7 +50,7 @@ class PVBrowserPage(Page):
         self.pv_browser_table.setModel(self.pv_browser_filter)
         self.pv_browser_table.setItemDelegateForColumn(PV_BROWSER_HEADER.TAGS.value, TagDelegate(self.client.backend.get_tags()))
         header_view = self.pv_browser_table.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.Fixed)
+        header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
         header_view.setStretchLastSection(True)
         header_view.sectionResized.connect(self.pv_browser_table.resizeRowsToContents)
         pv_browser_layout.addWidget(self.pv_browser_table)

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -85,7 +85,7 @@ class SearchPage(Display, QtWidgets.QWidget, WindowLinker):
         self.results_table_view.setModel(self.proxy_model)
         self.results_table_view.setSortingEnabled(True)
         horiz_header = self.results_table_view.horizontalHeader()
-        horiz_header.setSectionResizeMode(horiz_header.Interactive)
+        horiz_header.setSectionResizeMode(horiz_header.ResizeMode.Interactive)
 
         self.open_delegate = ButtonDelegate(button_text='open me')
         self.results_table_view.setItemDelegateForColumn(ResultsHeader.OPEN,

--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -95,7 +95,7 @@ class SnapshotComparisonPage(Page):
         self.comparison_table = SquirrelTableView()
         self.comparison_table.setModel(self.comparison_table_model)
         header_view = self.comparison_table.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.Stretch)
+        header_view.setSectionResizeMode(header_view.ResizeMode.Stretch)
         header_view.setSectionResizeMode(COMPARE_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(COMPARE_HEADER.SEVERITY.value, header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(COMPARE_HEADER.COMPARE_SEVERITY.value, header_view.ResizeMode.Fixed)

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -99,7 +99,7 @@ class SnapshotDetailsPage(Page):
         self.snapshot_details_table = SquirrelTableView()
         self.snapshot_details_table.setModel(self.snapshot_details_model)
         header_view = self.snapshot_details_table.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.Stretch)
+        header_view.setSectionResizeMode(header_view.ResizeMode.Stretch)
         header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeMode.Fixed)
@@ -227,7 +227,7 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
         self.table_view.doubleClicked.connect(self.accept)
         header_view = self.table_view.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
-        header_view.setSectionResizeMode(1, header_view.Stretch)
+        header_view.setSectionResizeMode(1, header_view.ResizeMode.Stretch)
         self.table_view.resizeColumnsToContents()
         main_layout.addWidget(self.table_view)
 

--- a/superscore/widgets/tag.py
+++ b/superscore/widgets/tag.py
@@ -175,7 +175,7 @@ class TagEditor(QtWidgets.QWidget):
         self.setLayout(layout)
 
         self.choice_list = QtWidgets.QListWidget()
-        self.choice_list.setSelectionMode(self.choice_list.MultiSelection)
+        self.choice_list.setSelectionMode(self.choice_list.SelectionMode.MultiSelection)
         self.layout().addWidget(self.choice_list)
         self.set_choices(choices)
 
@@ -224,7 +224,7 @@ class TagsWidget(QtWidgets.QWidget):
         The layout containing the widget's tag elements.
     """
 
-    tagSetChanged = QtCore.Signal(dict)
+    tagSetChanged = QtCore.Signal(object)  # PySide6 is cursed
 
     def __init__(
         self,

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -119,7 +119,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.snapshot_table.verticalHeader().hide()
         header_view = self.snapshot_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
-        header_view.setSectionResizeMode(1, header_view.Stretch)
+        header_view.setSectionResizeMode(1, header_view.ResizeMode.Stretch)
         self.snapshot_table.resizeColumnsToContents()
         view_snapshot_layout.addWidget(self.snapshot_table)
         return view_snapshot_page


### PR DESCRIPTION
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The PyQt5 package appears to no longer be available through conda channels. Plus, we're planning to transition towards pyside6 (eventually) anyway, so it doesn't hurt to get ahead.

Requires some code modifigurations for compatibility: mostly adding an enum reference inbetween a widget class and an enum member.

Pytest now produces a few warnings, but these are mostly in apischema, test_qt_helpers.py, and databridges which are likely to face removal anyway.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
