### PR TITLE
BLD: set ./tests/demo.cfg as backup config

### DIFF
--- a/superscore/client.py
+++ b/superscore/client.py
@@ -153,7 +153,11 @@ class Client:
                         logger.debug("Found configuration file at %r", full_path)
                         return full_path
         # If found nothing
-        raise OSError("No superscore configuration file found. Check SUPERSCORE_CFG.")
+        default_config = os.path.join(os.path.dirname(__file__), "tests/demo.cfg")
+        if os.path.isfile(default_config):
+            return default_config
+        else:
+            raise OSError("No superscore configuration file found")
 
     def search(self, *post: SearchTermType) -> Generator[Entry, None, None]:
         """

--- a/superscore/tests/config.cfg
+++ b/superscore/tests/config.cfg
@@ -1,7 +1,0 @@
-[backend]
-type = filestore
-path = ./db/filestore.json
-
-[control_layer]
-ca = true
-pva = true

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -17,7 +17,7 @@ from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
 from superscore.tests.conftest import (MockTaskStatus, nest_depth,
                                        setup_test_stack)
 
-SAMPLE_CFG = Path(__file__).parent / 'config.cfg'
+SAMPLE_CFG = Path(__file__).parent / 'demo.cfg'
 
 
 @pytest.fixture(scope='function')
@@ -143,7 +143,7 @@ def test_snap_RO(get_mock, test_client: Client, sample_database_fixture: Root):
 
 def test_from_cfg(sscore_cfg: str):
     client = Client.from_config()
-    assert isinstance(client.backend, FilestoreBackend)
+    assert isinstance(client.backend, DirectoryBackend)
     assert 'ca' in client.cl.shims
 
 


### PR DESCRIPTION
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `No configuration file found. Check SUPERSCORE_CFG` erro message received when first launching superscore after cloning is annoying and not very productive. We have default configs at `superscore/tests/config.cfg` and `superscore/tests/demo.cfg`, which people just copy when they get that message anyway.

This PR removes `config.cfg` and sets `demo.cfg` as the backup config to use if no config has been explicitly set via `SUPERSCOR_CFG`, `XDM_CONFIG_HOME`, or `~/.config/`.

Closes [SWAPPS-233](https://jira.slac.stanford.edu/browse/SWAPPS-233)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
