### PR TITLE
ENH: Add check after retrieving epics data

### DIFF
--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -269,10 +269,10 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             description=data.description,
             tolerance_abs=data.abs_tolerance if isinstance(data, Parameter) else None,
             tolerance_rel=data.rel_tolerance if isinstance(data, Parameter) else None,
-            lolo=epics_data.lower_alarm_limit,
-            low=epics_data.lower_warning_limit,
-            high=epics_data.upper_warning_limit,
-            hihi=epics_data.upper_alarm_limit,
+            lolo=epics_data.lower_alarm_limit if isinstance(epics_data, EpicsData) else None,
+            low=epics_data.lower_warning_limit if isinstance(epics_data, EpicsData) else None,
+            high=epics_data.upper_warning_limit if isinstance(epics_data, EpicsData) else None,
+            hihi=epics_data.upper_alarm_limit if isinstance(epics_data, EpicsData) else None,
             tags=None,
         )
         self.popup = PVDetailsPopup(pv_details)


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/SWAPPS-263

## Description
<!--- Describe individual changes -->
When the client attempts to retrieve data for alarm limits, it returns either EpicsData or CommunicationError.
Added checks to make sure it is the expected type before attempting to access the data, which should prevent it from crashing the app if unable to access the PV and a CommunicationError was returned.

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
