### PR TITLE
MNT: improve table view performance by only resizing columns to contents as needed

### DIFF
--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -96,11 +96,12 @@ class SnapshotComparisonPage(Page):
         self.comparison_table.verticalHeader().hide()
         header_view = self.comparison_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Stretch)
-        header_view.setSectionResizeMode(COMPARE_HEADER.CHECKBOX.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(COMPARE_HEADER.SEVERITY.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(COMPARE_HEADER.COMPARE_SEVERITY.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(COMPARE_HEADER.DEVICE.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(COMPARE_HEADER.PV.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(COMPARE_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(COMPARE_HEADER.SEVERITY.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(COMPARE_HEADER.COMPARE_SEVERITY.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(COMPARE_HEADER.DEVICE.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(COMPARE_HEADER.PV.value, header_view.ResizeMode.Fixed)
+        self.comparison_table.resizeColumnsToContents()
         snapshot_comparison_layout.addWidget(self.comparison_table)
 
     def set_main_snapshot(self, snapshot: Snapshot):

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -257,13 +257,15 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
         """Set the snapshot to be displayed in the details page."""
         if snapshot is self.snapshot:
             return
-
         self.snapshot = snapshot
-
-        header_text = f"Main Snapshot:\n    {self.snapshot.title}\n\n" \
-                      "Select a snapshot to compare to:"
-        self.header_label.setText(header_text)
-
+        self.header_label.setText(
+            "\n".join([
+                "Main Snapshot:",
+                f"      {self.snapshot.title}",
+                "",
+                "Select a snapshot to compare to:",
+            ])
+        )
         self.proxy_model.set_snapshot(self.snapshot)
 
 

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -214,9 +214,14 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
         self.header_label = QtWidgets.QLabel()
         main_layout.addWidget(self.header_label)
 
-        self.table_model = SnapshotTableModel(self.client)
         self.proxy_model = ExcludeCurrentSnapshotProxyModel(self, self.snapshot)
-        self.proxy_model.setSourceModel(self.table_model)
+        try:
+            main_window = self.parent().parent()
+            snapshot_table_model = main_window.snapshot_table.model()
+        except AttributeError:
+            snapshot_table_model = SnapshotTableModel(self.client)
+        finally:
+            self.proxy_model.setSourceModel(snapshot_table_model)
         self.table_view = QtWidgets.QTableView()
         self.table_view.setShowGrid(False)
         self.table_view.setModel(self.proxy_model)

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -241,7 +241,9 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
         buttonBox.rejected.connect(self.reject)
         main_layout.addWidget(buttonBox)
 
-        self.resize(450, 300)
+        column_count = self.table_view.model().columnCount()
+        full_width = sum([self.table_view.columnWidth(i) for i in range(column_count)])
+        self.resize(full_width, 450)
 
     @property
     def selected_snapshot(self):

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -101,10 +101,11 @@ class SnapshotDetailsPage(Page):
         self.snapshot_details_table.verticalHeader().hide()
         header_view = self.snapshot_details_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Stretch)
-        header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeToContents)
-        header_view.setSectionResizeMode(PV_HEADER.PV.value, header_view.ResizeToContents)
+        header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(PV_HEADER.SEVERITY.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(PV_HEADER.DEVICE.value, header_view.ResizeMode.Fixed)
+        header_view.setSectionResizeMode(PV_HEADER.PV.value, header_view.ResizeMode.Fixed)
+        self.snapshot_details_table.resizeColumnsToContents()
         snapshot_details_layout.addWidget(self.snapshot_details_table)
 
     def set_snapshot(self, snapshot: Snapshot) -> None:
@@ -229,8 +230,9 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
         self.table_view.doubleClicked.connect(self.accept)
         self.table_view.verticalHeader().hide()
         header_view = self.table_view.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.ResizeToContents)
+        header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(1, header_view.Stretch)
+        self.table_view.resizeColumnsToContents()
         main_layout.addWidget(self.table_view)
 
         btns = QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -113,8 +113,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         )
         self.snapshot_table.verticalHeader().hide()
         header_view = self.snapshot_table.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.ResizeToContents)
+        header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(1, header_view.Stretch)
+        self.snapshot_table.resizeColumnsToContents()
         view_snapshot_layout.addWidget(self.snapshot_table)
         return view_snapshot_page
 
@@ -168,8 +169,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.pv_browser_table.doubleClicked.connect(lambda index: self.open_pv_details(index, self.pv_browser_table))
         self.pv_browser_table.verticalHeader().hide()
         header_view = self.pv_browser_table.horizontalHeader()
-        header_view.setSectionResizeMode(header_view.ResizeToContents)
+        header_view.setSectionResizeMode(header_view.Fixed)
         header_view.setStretchLastSection(True)
+        self.pv_browser_table.resizeColumnsToContents()
         pv_browser_layout.addWidget(self.pv_browser_table)
         return pv_browser_page
 


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* Switch all `QTableView` columns with `ResizeToContents` resize mode to `Fixed`
* Call `QTableView.resizeColumnsToContents` once on initialization to set reasonable column widths
* Dynamically size comparison dialog on initialization to show whole table width
* Use main window's snapshot table as model for comparison dialog's proxy model
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `ResizeToContents` resize mode is relatively expensive, because it requires finding the widest cell in a column for each resize. Computing those widths once and then keeping them fixed saves the later, largely redundant computation.  We can call `QTableView.resizeColumnsToContents` additional times as needed, such as if new data is fetched and we want to make sure the columns resize properly. We can also change `Fixed` to `Interactive` so that users can do those later resizings for us.

Reusing the main window's snapshot table simply saves the time and space required to make a second, duplicate model. 

Closes [SWAPPS-260](https://jira.slac.stanford.edu/browse/SWAPPS-260)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
Unnecessary
## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
