### PR TITLE
GUI: Add tags to PVDetails

### DIFF
--- a/superscore/widgets/pv_details_components.py
+++ b/superscore/widgets/pv_details_components.py
@@ -27,6 +27,7 @@ class PVDetails:
     high: Optional[float] = None
     hihi: Optional[float] = None
 
+
 class PVDetailsTitleBar(QWidget):
     """Title bar for the PV details popup. Allows dragging and closing the popup."""
 
@@ -274,7 +275,6 @@ if __name__ == "__main__":
             print(f"Absolute Tolerance: {editable_popup.pv_details.tolerance_abs}")
             print(f"Relative Tolerance: {editable_popup.pv_details.tolerance_rel}")
             print(f"Tags: {editable_popup.pv_details.tags}")
-
 
     # Launch editable popup after readonly popup is closed
     readonly_popup.destroyed.connect(show_editable_popup)

--- a/superscore/widgets/pv_details_components.py
+++ b/superscore/widgets/pv_details_components.py
@@ -136,10 +136,8 @@ class PVDetailsPopup(QWidget):
         layout.addLayout(PVDetailsRow("HIGH:", QLabel(str(pv_details.high)), indent=1))
         layout.addLayout(PVDetailsRow("HIHI:", QLabel(str(pv_details.hihi)), indent=1))
 
-        tags_widget = TagsWidget(tag_groups=tag_groups, enabled=True)
-        for tag_group in tag_groups.keys():
-            if tag_group in pv_details.tags:
-                tags_widget.findChildren(TagChip)[tag_group].set_tags(tag_set[tag_group])
+        tags_widget = TagsWidget(tag_groups=tag_groups, enabled=False)
+        tags_widget.set_tags(pv_details.tags)
         layout.addLayout(PVDetailsRow("Tags", tags_widget, direction=QBoxLayout.TopToBottom))
         layout.addStretch()
 
@@ -170,9 +168,7 @@ class PVDetailsPopupEditable(QDialog):
 
         self.tags_input = TagsWidget(tag_groups=tag_groups, enabled=True)
         if initial_data:
-            for tag_group in tag_groups.keys():
-                if tag_group in initial_data.tags:
-                    self.tags_input.findChildren(TagChip)[tag_group].set_tags(tag_set[tag_group])
+            self.tags_input.set_tags(initial_data.tags)
 
         validator = QDoubleValidator(bottom=0.0, top=1e10, decimals=4)
         self.tolerance_abs_input.setValidator(validator)
@@ -235,7 +231,7 @@ class PVDetailsPopupEditable(QDialog):
                 description=self.description_input.text(),
                 tolerance_abs=float(self.tolerance_abs_input.text() or 0),
                 tolerance_rel=float(self.tolerance_rel_input.text() or 0),
-                tags=self.tags_input,
+                tags=self.tags_input.get_tag_set(),
             )
             self.accept()
         except ValueError as e:

--- a/superscore/widgets/pv_details_components.py
+++ b/superscore/widgets/pv_details_components.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import (QApplication, QBoxLayout, QDialog, QGridLayout,
                             QVBoxLayout, QWidget)
 
 from superscore.type_hints import TagDef, TagSet
-from superscore.widgets.tag import TagChip, TagsWidget
+from superscore.widgets.tag import TagsWidget
 
 
 @dataclass

--- a/superscore/widgets/pv_details_components.py
+++ b/superscore/widgets/pv_details_components.py
@@ -138,7 +138,7 @@ class PVDetailsPopup(QWidget):
 
         tags_widget = TagsWidget(tag_groups=tag_groups, enabled=True)
         for tag_group in tag_groups.keys():
-            if tag_group in tag_set:
+            if tag_group in pv_details.tags:
                 tags_widget.findChildren(TagChip)[tag_group].set_tags(tag_set[tag_group])
         layout.addLayout(PVDetailsRow("Tags", tags_widget, direction=QBoxLayout.TopToBottom))
         layout.addStretch()
@@ -171,7 +171,7 @@ class PVDetailsPopupEditable(QDialog):
         self.tags_input = TagsWidget(tag_groups=tag_groups, enabled=True)
         if initial_data:
             for tag_group in tag_groups.keys():
-                if tag_group in tag_set:
+                if tag_group in initial_data.tags:
                     self.tags_input.findChildren(TagChip)[tag_group].set_tags(tag_set[tag_group])
 
         validator = QDoubleValidator(bottom=0.0, top=1e10, decimals=4)

--- a/superscore/widgets/pv_details_components.py
+++ b/superscore/widgets/pv_details_components.py
@@ -1,5 +1,6 @@
 import sys
 from dataclasses import dataclass
+from typing import Optional
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QDoubleValidator, QFont
@@ -20,12 +21,11 @@ class PVDetails:
     description: str
     tolerance_abs: float
     tolerance_rel: float
-    lolo: float
-    low: float
-    high: float
-    hihi: float
     tags: TagSet
-
+    lolo: Optional[float] = None
+    low: Optional[float] = None
+    high: Optional[float] = None
+    hihi: Optional[float] = None
 
 class PVDetailsTitleBar(QWidget):
     """Title bar for the PV details popup. Allows dragging and closing the popup."""
@@ -273,6 +273,8 @@ if __name__ == "__main__":
             print(f"Description: {editable_popup.pv_details.description}")
             print(f"Absolute Tolerance: {editable_popup.pv_details.tolerance_abs}")
             print(f"Relative Tolerance: {editable_popup.pv_details.tolerance_rel}")
+            print(f"Tags: {editable_popup.pv_details.tags}")
+
 
     # Launch editable popup after readonly popup is closed
     readonly_popup.destroyed.connect(show_editable_popup)

--- a/superscore/widgets/tag.py
+++ b/superscore/widgets/tag.py
@@ -292,6 +292,7 @@ class TagsWidget(QtWidgets.QWidget):
         chips = self.findChildren(TagChip)
         for chip in chips:
             tag_set[chip.tag_group] = chip.tags
+        return tag_set
 
     def get_group_chip(self, tag_group: int) -> TagChip | None:
         """Returns TagChip corresponding to the desired tag group, or None if chip was not found"""

--- a/superscore/widgets/tag.py
+++ b/superscore/widgets/tag.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import qtawesome as qta
 from qtpy import QtCore, QtWidgets
@@ -294,7 +294,7 @@ class TagsWidget(QtWidgets.QWidget):
             tag_set[chip.tag_group] = chip.tags
         return tag_set
 
-    def get_group_chip(self, tag_group: int) -> TagChip | None:
+    def get_group_chip(self, tag_group: int) -> Optional[TagChip]:
         """Returns TagChip corresponding to the desired tag group, or None if chip was not found"""
         chips = self.findChildren(TagChip)
         for chip in chips:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -296,9 +296,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             low=epics_data.lower_warning_limit if isinstance(epics_data, EpicsData) else None,
             high=epics_data.upper_warning_limit if isinstance(epics_data, EpicsData) else None,
             hihi=epics_data.upper_alarm_limit if isinstance(epics_data, EpicsData) else None,
-            tags=None,
+            tags=data.tags,
         )
-        self.popup = PVDetailsPopup(pv_details)
+        self.popup = PVDetailsPopup(tag_groups=self.client.backend.get_tags(), pv_details=pv_details)
         self.popup.adjustSize()
 
         table_top_right = view.mapToGlobal(view.rect().topRight())


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Adds the implemented TagsWidget to the PV details popups. Also adds some helper functions to TagsWidget to make it easier to control and retrieve data from the child TagChips. To type hint it, I had to move TagsWidget to the bottom of the file.

<img width="198" alt="image" src="https://github.com/user-attachments/assets/8303267a-58c4-482c-9df3-4dbe6f37dc56" />

![image](https://github.com/user-attachments/assets/df112ec2-8176-4163-9803-159e1caab176)

I observed some issues related to the tag chips:

- Non-editable chip style broke - apparently this is pretty finicky
- TagEditor doesn't correctly set selected tags - this results in clearing the tags when first modifying them

By the way, only the read-only pv details popup is currently in use - where would the editable one go?

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
