### PR TITLE
GUI: copy underlying epics address when middle-clicking table cell

### DIFF
--- a/superscore/widgets/page/snapshot_comparison.py
+++ b/superscore/widgets/page/snapshot_comparison.py
@@ -6,6 +6,7 @@ from superscore.model import Snapshot
 from superscore.widgets.page.page import Page
 from superscore.widgets.snapshot_comparison_table import (
     COMPARE_HEADER, SnapshotComparisonTableModel)
+from superscore.widgets.squirrel_table_view import SquirrelTableView
 
 
 class SnapshotComparisonPage(Page):
@@ -91,10 +92,8 @@ class SnapshotComparisonPage(Page):
 
         # Add a table to show the comparison result
         self.comparison_table_model = SnapshotComparisonTableModel(self.client, self)
-        self.comparison_table = QtWidgets.QTableView()
-        self.comparison_table.setSelectionBehavior(self.comparison_table.SelectionBehavior.SelectRows)
+        self.comparison_table = SquirrelTableView()
         self.comparison_table.setModel(self.comparison_table_model)
-        self.comparison_table.verticalHeader().hide()
         header_view = self.comparison_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Stretch)
         header_view.setSectionResizeMode(COMPARE_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)

--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -6,6 +6,7 @@ from superscore.model import Snapshot
 from superscore.widgets.page.page import Page
 from superscore.widgets.pv_table import PV_HEADER, PVTableModel
 from superscore.widgets.snapshot_table import SnapshotTableModel
+from superscore.widgets.squirrel_table_view import SquirrelTableView
 
 
 class SnapshotDetailsPage(Page):
@@ -95,11 +96,8 @@ class SnapshotDetailsPage(Page):
         self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
         self.pv_table_models[self.snapshot.uuid] = self.snapshot_details_model
 
-        self.snapshot_details_table = QtWidgets.QTableView()
+        self.snapshot_details_table = SquirrelTableView()
         self.snapshot_details_table.setModel(self.snapshot_details_model)
-        self.snapshot_details_table.setShowGrid(False)
-        self.snapshot_details_table.setSelectionBehavior(self.snapshot_details_table.SelectionBehavior.SelectRows)
-        self.snapshot_details_table.verticalHeader().hide()
         header_view = self.snapshot_details_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Stretch)
         header_view.setSectionResizeMode(PV_HEADER.CHECKBOX.value, header_view.ResizeMode.Fixed)
@@ -224,12 +222,9 @@ class SnapshotComparisonDialog(QtWidgets.QDialog):
             snapshot_table_model = SnapshotTableModel(self.client)
         finally:
             self.proxy_model.setSourceModel(snapshot_table_model)
-        self.table_view = QtWidgets.QTableView()
-        self.table_view.setShowGrid(False)
-        self.table_view.setSelectionBehavior(self.table_view.SelectionBehavior.SelectRows)
+        self.table_view = SquirrelTableView()
         self.table_view.setModel(self.proxy_model)
         self.table_view.doubleClicked.connect(self.accept)
-        self.table_view.verticalHeader().hide()
         header_view = self.table_view.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeMode.Fixed)
         header_view.setSectionResizeMode(1, header_view.Stretch)

--- a/superscore/widgets/pv_browser_table.py
+++ b/superscore/widgets/pv_browser_table.py
@@ -57,16 +57,19 @@ class PVBrowserTableModel(QtCore.QAbstractTableModel):
         index: QtCore.QModelIndex,
         role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
     ) -> Any:
+        column = PV_BROWSER_HEADER(index.column())
         if not index.isValid():
             return None
         elif role == QtCore.Qt.TextAlignmentRole and index.data() == NO_DATA:
             return QtCore.Qt.AlignCenter
         elif role == QtCore.Qt.ToolTipRole:
             entry = self._data[index.row()]
-            return entry.pv_name
+            if column == PV_BROWSER_HEADER.PV:
+                return entry.pv_name
+            elif column == PV_BROWSER_HEADER.READBACK and entry.readback is not None:
+                return entry.readback.pv_name
         elif role == QtCore.Qt.DisplayRole:
             entry = self._data[index.row()]
-            column = PV_BROWSER_HEADER(index.column())
             if column == PV_BROWSER_HEADER.DEVICE:
                 return None
             elif column == PV_BROWSER_HEADER.PV:

--- a/superscore/widgets/pv_table.py
+++ b/superscore/widgets/pv_table.py
@@ -143,6 +143,23 @@ class PVTableModel(LivePVTableModel):
                     return None
                 else:
                     return None
+        elif role == QtCore.Qt.ToolTipRole:
+            if isinstance(entry, Setpoint):
+                if column == PV_HEADER.SEVERITY:
+                    return entry.pv_name + ".SEVR"
+                elif column in (PV_HEADER.PV, PV_HEADER.SETPOINT, PV_HEADER.LIVE_SETPOINT):
+                    return entry.pv_name
+                elif column in (PV_HEADER.READBACK, PV_HEADER.LIVE_READBACK) and entry.readback is not None:
+                    return entry.readback.pv_name
+                elif column == PV_HEADER.CONFIG:
+                    return None
+            else:
+                if column == PV_HEADER.SEVERITY:
+                    return entry.pv_name + ".SEVR"
+                elif column in (PV_HEADER.READBACK, PV_HEADER.LIVE_READBACK):
+                    return entry.pv_name
+                elif column == PV_HEADER.CONFIG:
+                    return None
         elif role == QtCore.Qt.CheckStateRole and column == PV_HEADER.CHECKBOX:
             return index.row() in self._checked
         elif role == QtCore.Qt.DecorationRole and column == PV_HEADER.SEVERITY:

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -29,17 +29,24 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
         index: QtCore.QModelIndex,
         role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
     ):
+        column = index.column()
         if role == QtCore.Qt.DisplayRole:
-            entry = self._data[index.row()]
-            if (column := index.column()) == 0:
-                return entry.creation_time.strftime("%Y-%m-%d %H:%M:%S")
+            snapshot = self._data[index.row()]
+            if column == 0:
+                return snapshot.creation_time.strftime("%Y-%m-%d %H:%M:%S")
             elif column == 1:
-                return entry.title
+                return snapshot.title
             else:
                 try:
-                    return entry.meta_pvs[column - len(self.HEADER)].data
+                    return snapshot.meta_pvs[column - len(self.HEADER)].data
                 except IndexError:
                     return None
+        elif role == QtCore.Qt.ToolTipRole and column >= 2:
+            snapshot = self._data[index.row()]
+            try:
+                return snapshot.meta_pvs[column - len(self.HEADER)].pv_name
+            except IndexError:
+                return None
         else:
             return None
 

--- a/superscore/widgets/squirrel_table_view.py
+++ b/superscore/widgets/squirrel_table_view.py
@@ -1,0 +1,24 @@
+from qtpy import QtCore, QtWidgets
+
+
+class SquirrelTableView(QtWidgets.QTableView):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setShowGrid(False)
+        self.verticalHeader().hide()
+        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.MiddleButton:
+            self.copy_address(self.indexAt(event.position().toPoint()))
+        else:
+            super().mousePressEvent(event)
+
+    def copy_address(self, index):
+        text = self.model().data(index, QtCore.Qt.ToolTipRole)
+        clipboard = QtWidgets.QApplication.clipboard()
+        if clipboard.supportsSelection():
+            mode = clipboard.Selection
+        else:
+            mode = clipboard.Clipboard
+        clipboard.setText(text, mode=mode)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -26,6 +26,7 @@ from superscore.widgets.pv_browser_table import (PVBrowserFilterProxyModel,
 from superscore.widgets.pv_details_components import PVDetails, PVDetailsPopup
 from superscore.widgets.pv_table import PVTableModel
 from superscore.widgets.snapshot_table import SnapshotTableModel
+from superscore.widgets.squirrel_table_view import SquirrelTableView
 from superscore.widgets.views import DiffDispatcher
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.setCentralWidget(central_widget)
 
         self.setStyleSheet(
-            "QTableView::item {"
+            "SquirrelTableView::item {"
             "    border: 0px;"
             f"    border-top: 1px solid {superscore.color.TABLE_GRID};"
             f"    border-bottom: 1px solid {superscore.color.TABLE_GRID};"
@@ -102,7 +103,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         view_snapshot_layout.setContentsMargins(0, 11, 0, 0)
         view_snapshot_page.setLayout(view_snapshot_layout)
 
-        self.snapshot_table = QtWidgets.QTableView()
+        self.snapshot_table = SquirrelTableView()
         self.snapshot_table.setModel(SnapshotTableModel(self.client))
         self.snapshot_table.doubleClicked.connect(self.open_snapshot_index)
         self.snapshot_table.setShowGrid(False)
@@ -164,12 +165,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         search_bar_lyt.addSpacerItem(spacer)
         pv_browser_layout.addLayout(search_bar_lyt)
 
-        self.pv_browser_table = QtWidgets.QTableView(pv_browser_page)
-        self.pv_browser_table.setShowGrid(False)
-        self.pv_browser_table.setSelectionBehavior(self.pv_browser_table.SelectionBehavior.SelectRows)
+        self.pv_browser_table = SquirrelTableView(pv_browser_page)
         self.pv_browser_table.setModel(pv_browser_filter)
         self.pv_browser_table.doubleClicked.connect(lambda index: self.open_pv_details(index, self.pv_browser_table))
-        self.pv_browser_table.verticalHeader().hide()
         header_view = self.pv_browser_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.Fixed)
         header_view.setStretchLastSection(True)


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* implement `SquirrelTableView`, which includes some basic table styling, and use for snapshot list, PV details, and comparison tables
* implement `SquirrelTableView.copy_address`, which copies tooltip data to clipboard
* intercept table middle-clicks to call `.copy_address`
* add `ToolTipRole` data to `SnapshotTableModel` and `PVTableModel`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Operators are used to being able to middle-click widgets to display the underlying epics address and copy it to the clipboard.  This functionality this also built in to `PyDMPrimitiveWidget`.  Providing this feature for PV-related tables thus improves user experience and utility.

Closes [SWAPPS-262](https://jira.slac.stanford.edu/browse/SWAPPS-262)
Partially resolves [SWAPPS-261](https://jira.slac.stanford.edu/browse/SWAPPS-261) 
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
![Screenshot 2025-06-24 at 08 51 18](https://github.com/user-attachments/assets/910b053a-290f-4fcf-815a-79e1a053066f)
![Screenshot 2025-06-24 at 08 51 35](https://github.com/user-attachments/assets/1601a2d0-5231-4ca0-b07c-b210b8e5b78f)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
