### PR TITLE
GUI: hide empty disabled TagChips

### DIFF
--- a/superscore/widgets/tag.py
+++ b/superscore/widgets/tag.py
@@ -266,16 +266,13 @@ class TagsWidget(QtWidgets.QWidget):
             Additional keyword arguments passed to the base QWidget.
         """
         super().__init__(*args, **kwargs)
-        self.tag_groups = tag_groups
-
-        self.setEnabled(enabled)
-
-        self.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
 
         self.setLayout(FlowLayout(margin=0, spacing=5))
         self.layout().setObjectName("TagChipFlowLayout")
+        self.set_tag_groups(tag_groups)
 
-        self.set_tag_groups(self.tag_groups)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
+        self.setEnabled(enabled)
 
     def emitTagSetChanged(self) -> None:
         """Emits the tagSetChanged signal with the widget's current TagSet"""
@@ -299,10 +296,14 @@ class TagsWidget(QtWidgets.QWidget):
     def set_tags(self, tag_set: TagSet) -> None:
         """Sets the child TagChips according to the provided TagSet"""
         self.clear_tags()
-        for tag_group in tag_set:
+        for tag_group, tags in tag_set.items():
             chip = self.get_group_chip(tag_group)
             if isinstance(chip, TagChip):
-                chip.set_tags(tag_set[tag_group])
+                chip.set_tags(tags)
+                if len(tags) == 0:
+                    chip.hide()
+                else:
+                    chip.show()
 
     def get_tag_set(self) -> TagSet:
         """Constructs the TagSet representation of the child TagChips"""
@@ -319,3 +320,12 @@ class TagsWidget(QtWidgets.QWidget):
             if chip.tag_group == tag_group:
                 return chip
         return None
+
+    def setEnabled(self, enabled: bool = False):
+        super().setEnabled(enabled)
+        for i in range(self.layout().count()):
+            chip = self.layout().itemAt(i).widget()
+            if not enabled and len(chip.tags) == 0:
+                chip.hide()
+            else:
+                chip.show()


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* Call `.hide()` or `.show()` on `TagChip`s during `TagsWidget.setEnabled` and `TagsWidget.set_tags`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a `TagsWidget` is disabled, we're typically showing a static set of tags e.g. the tags associated with a PV. In this context, the empty chips represent tags that have not been set, so the chips clutter the view without providing any information. This PR hides chips in that context.

Chip visibility is managed in `TagsWidget` rather than in `TagChip` so that chips can be created and managed individually if desired.

Closes [SWAPPS-275](https://jira.slac.stanford.edu/browse/SWAPPS-275)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
![Screenshot 2025-07-01 at 08 56 04](https://github.com/user-attachments/assets/3c722d05-f408-486e-ad14-545065611d76)
Note: The `TagsWidget` in this screenshot is not normally disabled, but it was the easiest way to show a test case. The screen is not behaving correctly as shown, except for the `TagsWidget`. 

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
