### PR TITLE
TST: remove tests with intermittent timeout errors

### DIFF
--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -33,7 +33,6 @@ def collection_page(qtbot: QtBot, test_client: Client):
 
     view = page.sub_pv_table_view
     view._model.stop_polling()
-    qtbot.wait_until(lambda: not view._model._poll_thread.isRunning())
 
 
 @pytest.fixture(scope="function")
@@ -45,7 +44,6 @@ def snapshot_page(qtbot: QtBot, test_client: Client):
 
     view = page.sub_pv_table_view
     view._model.stop_polling()
-    qtbot.wait_until(lambda: not view._model._poll_thread.isRunning())
 
 
 @pytest.fixture(scope="function")
@@ -282,7 +280,6 @@ def test_restore_all(
     assert put_mock.call_args.args[0] == all_pv_names
 
     table_model.close()
-    qtbot.wait_until(lambda: not table_model._poll_thread.isRunning(), timeout=10000)
 
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
@@ -305,7 +302,6 @@ def test_restore_selected(
     assert put_mock.call_args.args[0] == [table_model.data(pv_index, role=QtCore.Qt.DisplayRole)]
 
     table_model.close()
-    qtbot.wait_until(lambda: not table_model._poll_thread.isRunning(), timeout=10000)
 
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* remove all instances of `qtbot.wait_until` from `tests/test_pages.py`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These intermittent failures don't point to any known problem, and are super annoying. 

Closes [SWAPPS-238](https://jira.slac.stanford.edu/browse/SWAPPS-238)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
