### PR TITLE
DOC: remove superfluous dependencies and point docs link to slaclab location

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,9 +56,9 @@ extensions = [
     # jquery removed in sphinx 6.0 and used in docs_versions_menu.
     # See: https://www.sphinx-doc.org/en/master/changes.html
     "sphinxcontrib.jquery",
-    "numpydoc",
-    "recommonmark",
-    "docs_versions_menu",
+    # "numpydoc",
+    # "recommonmark",
+    # "docs_versions_menu",
     "sphinx_rtd_theme",
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ Welcome to superscore's documentation!
    :caption: Links
    :hidden:
 
-   Github Repository <https://github.com/pcdshub/superscore>
+   Github Repository <https://github.com/slaclab/superscore>
 
 
 


### PR DESCRIPTION
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempting to get docs build workflow to begin triggering automatically. 
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
