### PR TITLE
BUG: use pyside6 enum when setting filter case sensitivity

### DIFF
--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -100,7 +100,7 @@ class SnapshotDetailsPage(Page):
         proxy_model = QtCore.QSortFilterProxyModel()
         proxy_model.setSourceModel(self.snapshot_details_model)
         proxy_model.setFilterKeyColumn(PV_HEADER.PV.value)
-        proxy_model.setFilterCaseSensitivity(False)
+        proxy_model.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
         self.snapshot_details_table.setModel(proxy_model)
         header_view = self.snapshot_details_table.horizontalHeader()
         header_view.setSectionResizeMode(header_view.ResizeMode.Stretch)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -132,7 +132,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.snapshot_table = SquirrelTableView()
         snapshot_model = SnapshotTableModel(self.client)
         proxy_model = SnapshotFilterModel()
-        proxy_model.setFilterCaseSensitivity(False)
+        proxy_model.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
         proxy_model.setSourceModel(snapshot_model)
         self.snapshot_table.setModel(proxy_model)
         self.snapshot_table.doubleClicked.connect(self.open_snapshot_index)


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* use `QtCore.Qt.CaseSensitivity` enum as parameter in `QSortFilterProxyModel.setFilterCaseSensitivity`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes compatibility with pyside6
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
