### PR TITLE
ENH: activate logging to stdout

### DIFF
--- a/superscore/bin/main.py
+++ b/superscore/bin/main.py
@@ -9,6 +9,7 @@ import argparse
 import asyncio
 import importlib
 import logging
+import sys
 from inspect import iscoroutinefunction
 
 import superscore
@@ -103,6 +104,11 @@ def main():
     log_level = kwargs.pop('log_level')
     admin_mode = kwargs.pop('admin')
     logger.setLevel(log_level)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     if admin_mode:
         permission_manager = PermissionManager.get_instance()


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* set stream handler on logger, which is what actually writes logs to `stdout`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logs are great, but setting `--log {level}` didn't actually do anything.  With this PR, setting a log level will stream logs to `stdout`.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
Example logging output from launching and then closing the app:
```
(squirrel) dev-srv09:~/src/superscore/superscore$ superscore --log DEBUG ui
2025-08-01 09:17:23,191 - superscore - DEBUG - main(**{'cfg_path': None})
2025-08-01 09:17:24,492 - superscore.client - DEBUG - Searching for superscore config in .
2025-08-01 09:17:24,492 - superscore.client - DEBUG - Searching for superscore config in /sdf/home/d/devagr/.config
2025-08-01 09:17:24,493 - superscore.client - DEBUG - Loading configuration file at (/sdf/home/d/devagr/src/superscore/superscore/tests/demo.cfg)
2025-08-01 09:17:24,494 - superscore.control_layers.core - DEBUG - Loaded valid shims from the requested list: ['ca']
2025-08-01 09:17:25,952 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 0 with entry: Parameter(uuid=UUID('7cb3760c-793c-4974-a8ae-778e5d491e4a'), description='Second LASR pv in GUNB', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='LASR:GUNB:TEST2', abs_tolerance=None, rel_tolerance=None, tags={0: {0, 1}, 2: {2}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,952 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 1 with entry: Parameter(uuid=UUID('5544c58f-88b6-40aa-9076-f180a44908f5'), description='First LASR pv in GUNB', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='LASR:GUNB:TEST1', abs_tolerance=None, rel_tolerance=None, tags={0: {0, 1}, 2: {2}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 2 with entry: Parameter(uuid=UUID('5ec33c74-7f4c-4905-a106-44fbfe138140'), description='Only VAC pv in L0B', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:L0B:TEST0', abs_tolerance=None, rel_tolerance=None, tags={2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 3 with entry: Parameter(uuid=UUID('f802dee1-569b-4c6b-a32f-c213af10ecec'), description='Only laser pv in IN10', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='LASR:IN10:TEST0', abs_tolerance=None, rel_tolerance=None, tags={2: {2}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 4 with entry: Parameter(uuid=UUID('a13ef8a5-b8df-4caa-80f5-395b16eaa5f1'), description='Only laser pv in IN20', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='LASR:IN20:TEST0', abs_tolerance=None, rel_tolerance=None, tags={0: {1}, 2: {2}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 5 with entry: Parameter(uuid=UUID('06448272-cd38-4bb4-9b8d-292673a497e9'), description='Second VAC pv in GUNB', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:GUNB:TEST2', abs_tolerance=None, rel_tolerance=None, tags={0: {0, 1}, 2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 6 with entry: Parameter(uuid=UUID('030786df-153b-4d29-bc1f-66deeb116724'), description='Only VAC pv in BSY', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:BSY:TEST0', abs_tolerance=None, rel_tolerance=None, tags={0: {1}, 2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,953 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 7 with entry: Parameter(uuid=UUID('930b137f-5ae2-470e-8b82-c4b4eb7e639e'), description='Only MGNT pv in GUNB', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='MGNT:GUNB:TEST0', abs_tolerance=None, rel_tolerance=None, tags={0: {0, 1}, 2: {0}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 8 with entry: Parameter(uuid=UUID('2c83a9be-bec6-4436-8233-79df300af670'), description='Only VAC pv in LI10', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:LI10:TEST0', abs_tolerance=None, rel_tolerance=None, tags={2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 9 with entry: Parameter(uuid=UUID('8f3ac401-68f8-4def-b65a-3c8116c80ba7'), description='First VAC pv in GUNB', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:GUNB:TEST1', abs_tolerance=None, rel_tolerance=None, tags={0: {0, 1}, 2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Filtering row 10 with entry: Parameter(uuid=UUID('8dba63d5-98e8-4647-ae44-ff0a38a4805d'), description='Only VAC pv in LI21', creation_time=datetime.datetime(2025, 7, 23, 20, 48, 46, 535789, tzinfo=datetime.timezone.utc), pv_name='VAC:LI21:TEST0', abs_tolerance=None, rel_tolerance=None, tags={0: {1}, 2: {3}, 3: {0, 1}}, readback=None, read_only=False)
2025-08-01 09:17:25,954 - superscore.widgets.pv_browser_table - DEBUG - Tag values subset: True
2025-08-01 09:17:30,864 - superscore.control_layers._aioca - DEBUG - CA get failed CANothing('VAC:LI10:TEST0', 80)
2025-08-01 09:17:33,875 - superscore.widgets.views - DEBUG - Stopping pv_model polling
2025-08-01 09:17:33,875 - superscore.widgets.views - DEBUG - stopping and de-referencing thread @ 140025645101888
2025-08-01 09:17:35,865 - superscore.control_layers._aioca - DEBUG - CA get failed CANothing('VAC:GUNB:TEST2', 80)
```
## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
