### PR TITLE
ENH: Add ability to filter snapshots based on meta pvs

### DIFF
--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -365,8 +365,8 @@ def linac_data() -> Root:
 
     all_snapshot.meta_pvs = [
         hxr_pulse_readback,
-        sxr_pulse_readback,
         hxr_edes_readback,
+        sxr_pulse_readback,
         sxr_edes_readback
     ]
 

--- a/superscore/tests/test_snapshot_table.py
+++ b/superscore/tests/test_snapshot_table.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from qtpy import QtCore
 from unittest.mock import Mock
+
+from qtpy import QtCore
+
 from superscore.model import Readback
 from superscore.widgets.snapshot_table import SnapshotFilterModel
 

--- a/superscore/tests/test_snapshot_table.py
+++ b/superscore/tests/test_snapshot_table.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from qtpy import QtCore
+from unittest.mock import Mock
+from superscore.model import Readback
+from superscore.widgets.snapshot_table import SnapshotFilterModel
+
+
+def test_meta_pv_numeric_filter():
+    """Verify that the logic around filtering meta pvs works as expected"""
+    # Set up a mock snapshot model with two snapshots, each containing the same two meta PV names
+    snapshot1 = Mock()
+    snapshot1.creation_time = datetime(2025, 8, 4)
+    snapshot1.meta_pvs = [
+        Readback(description="HXR Pulse Intensity", data="7.5"),
+        Readback(description="SXR Pulse Intensity", data="10.25"),
+    ]
+
+    snapshot2 = Mock()
+    snapshot2.creation_time = datetime(2025, 8, 4)
+    snapshot2.meta_pvs = [
+        Readback(description="HXR Pulse Intensity", data="7.5"),
+        Readback(description="SXR Pulse Intensity", data="15.0"),
+    ]
+
+    source_model = Mock()
+    source_model._data = [snapshot1, snapshot2]
+
+    filter_model = SnapshotFilterModel()
+    filter_model.sourceModel = lambda: source_model
+
+    # Always allow both snapshots based on creation dates
+    filter_model.setDateRange(
+        QtCore.QDate(2024, 1, 1),
+        QtCore.QDate(2025, 12, 31)
+    )
+
+    # Matches both since HXR Pulse Intensity is 7.5 for each
+    filter_model.setMetaPVFilters([
+        {"column": "HXR Pulse Intensity", "operator": ">", "value": "7"}
+    ])
+    assert filter_model.filterAcceptsRow(0, QtCore.QModelIndex())
+    assert filter_model.filterAcceptsRow(1, QtCore.QModelIndex())
+
+    # And so the opposite should not match either one
+    filter_model.setMetaPVFilters([
+        {"column": "HXR Pulse Intensity", "operator": "<", "value": "7"}
+    ])
+    assert not filter_model.filterAcceptsRow(0, QtCore.QModelIndex())
+    assert not filter_model.filterAcceptsRow(1, QtCore.QModelIndex())
+
+    # Check that applying two separate filters to the same meta pv works
+    filter_model.setMetaPVFilters([
+        {"column": "SXR Pulse Intensity", "operator": ">", "value": "10.0"},
+        {"column": "SXR Pulse Intensity", "operator": "<=", "value": "13.0"}
+    ])
+    assert filter_model.filterAcceptsRow(0, QtCore.QModelIndex())
+    assert not filter_model.filterAcceptsRow(1, QtCore.QModelIndex())
+
+    # And filter on both meta PVs at the same time
+    filter_model.setMetaPVFilters([
+        {"column": "HXR Pulse Intensity", "operator": "=", "value": "7.5"},
+        {"column": "SXR Pulse Intensity", "operator": "!=", "value": "13.0"}
+    ])
+    assert filter_model.filterAcceptsRow(0, QtCore.QModelIndex())
+    assert filter_model.filterAcceptsRow(1, QtCore.QModelIndex())

--- a/superscore/widgets/filter_bar.py
+++ b/superscore/widgets/filter_bar.py
@@ -1,0 +1,113 @@
+from qtpy import QtWidgets, QtCore
+
+
+class FilterRow(QtWidgets.QWidget):
+    """
+    A single row of filter inputs: column, operator, and input value.
+
+    Parameters
+    ----------
+    column_names : list[str]
+        The columns to apply filters to. Names can be dynamic, multiple filters can be applied to each.
+    parent : QtWidgets.QWidget | None
+        The parent widget of this object.
+    """
+
+    filter_changed = QtCore.Signal()
+    filter_removed = QtCore.Signal(QtWidgets.QWidget)
+
+    def __init__(self, column_names: list[str], parent : QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.column_dropdown = QtWidgets.QComboBox()
+        self.column_dropdown.addItems(column_names)
+
+        self.operator_dropdown = QtWidgets.QComboBox()
+        self.operator_dropdown.addItems(["=", "!=", "<", "<=", ">", ">="])
+
+        # The value the user types to compare against
+        self.input_value = QtWidgets.QLineEdit()
+
+        self.remove_button = QtWidgets.QToolButton()
+        self.remove_button.setText("×")
+        self.remove_button.setFixedWidth(24)
+
+        layout.addWidget(self.column_dropdown)
+        layout.addWidget(self.operator_dropdown)
+        layout.addWidget(self.input_value)
+        layout.addWidget(self.remove_button)
+
+        # Signals
+        self.column_dropdown.currentIndexChanged.connect(self.filter_changed)
+        self.operator_dropdown.currentIndexChanged.connect(self.filter_changed)
+        self.input_value.textChanged.connect(self.filter_changed)
+        self.remove_button.clicked.connect(lambda: self.filter_removed.emit(self))
+
+    def get_filter(self) -> dict[str, str]:
+        """Return filter expression as a dictionary"""
+        return {
+            "column": self.column_dropdown.currentText(),
+            "operator": self.operator_dropdown.currentText(),
+            "value": self.input_value.text(),
+        }
+
+
+class FilterBar(QtWidgets.QWidget):
+    """
+    Container widget that can hold multiple FilterRow widgets.
+
+    Parameters
+    ----------
+    column_names : list[str]
+        The columns to apply filters to. Names can be dynamic, multiple filters can be applied to each.
+    parent : QtWidgets.QWidget | None
+        The parent widget of this object.
+    """
+
+    filters_updated = QtCore.Signal()
+
+    def __init__(self, column_names: list[str], parent : QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.column_names = column_names
+
+        self.main_layout = QtWidgets.QVBoxLayout(self)
+        self.row_container = QtWidgets.QVBoxLayout()
+        self.row_container.setSpacing(10)
+
+        self.add_filter_button = QtWidgets.QPushButton("+ Add")
+        self.add_filter_button.clicked.connect(self.add_filter_row)
+
+        self.main_layout.addLayout(self.row_container)
+
+        add_button_layout = QtWidgets.QHBoxLayout()
+        add_button_layout.setContentsMargins(0, 0, 0, 0)
+        add_button_layout.addWidget(self.add_filter_button)
+        add_button_layout.addStretch()
+
+        self.main_layout.addLayout(add_button_layout)
+
+        self.filter_rows = []
+        self.add_filter_row()  # Always start with one empty row
+
+    def add_filter_row(self) -> None:
+        """Add a new row for filtering a column to this widget"""
+        row = FilterRow(self.column_names, self)
+        self.filter_rows.append(row)
+        self.row_container.addWidget(row)
+
+        row.filter_changed.connect(self.filters_updated.emit)
+        row.filter_removed.connect(self.remove_filter_row)
+        self.filters_updated.emit()
+
+    def remove_filter_row(self, row: FilterRow) -> None:
+        """Remove an existing row from this widget"""
+        self.filter_rows.remove(row)
+        self.row_container.removeWidget(row)
+        row.deleteLater()
+        self.filters_updated.emit()
+
+    def get_filters(self) -> list[dict]:
+        """Return all active filters"""
+        return [row.get_filter() for row in self.filter_rows if row.input_value.text()]

--- a/superscore/widgets/filter_bar.py
+++ b/superscore/widgets/filter_bar.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets, QtCore
+from qtpy import QtCore, QtWidgets
 
 
 class FilterRow(QtWidgets.QWidget):

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -1,3 +1,4 @@
+import operator
 from qtpy import QtCore
 
 from superscore.model import Snapshot
@@ -80,19 +81,65 @@ class SnapshotTableModel(QtCore.QAbstractTableModel):
 
 
 class SnapshotFilterModel(QtCore.QSortFilterProxyModel):
+    SUPPORTED_OPERATORS = {
+        "=": operator.eq,
+        "!=": operator.ne,
+        "<": operator.lt,
+        "<=": operator.le,
+        ">": operator.gt,
+        ">=": operator.ge,
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setFilterKeyColumn(1)
         self.since = QtCore.QDate.currentDate().addYears(-1)
         self.until = QtCore.QDate.currentDate()
+        self.filters = [] # List that contains: [{column, operator, value}]
 
     def filterAcceptsRow(self, row: int, parent: QtCore.QModelIndex) -> bool:
         datetime = self.sourceModel()._data[row].creation_time
         date = QtCore.QDate(datetime.year, datetime.month, datetime.day)
         is_date_in_range = self.since <= date and date <= self.until
-        return is_date_in_range and super().filterAcceptsRow(row, parent)
+
+        if not is_date_in_range:
+            return False
+
+        # Meta PV filtering
+        snapshot = self.sourceModel()._data[row]
+        for meta_pv_filter in self.filters:
+            column_name = meta_pv_filter["column"]
+            input_operator = meta_pv_filter["operator"]
+            input_value = meta_pv_filter["value"]
+
+            comparison_function = self.SUPPORTED_OPERATORS.get(input_operator)
+
+            # Retrieve the data for the corresponding meta_pv
+            matching_pvs = [pv for pv in snapshot.meta_pvs if pv.description == column_name]
+            pv_value = matching_pvs[0].data
+
+            try:
+                pv_value = float(pv_value)
+                input_value = float(input_value)
+            except (ValueError, TypeError):
+                pv_value = str(pv_value)
+                input_value = str(input_value)
+
+            try:
+                if not comparison_function(pv_value, input_value):
+                    return False
+            except Exception as e:
+                print(f'Exception applying filter: {e}')
+                return False
+
+        return super().filterAcceptsRow(row, parent)
 
     def setDateRange(self, since: QtCore.QDate, until: QtCore.QDate):
         self.since = since
         self.until = until
+        self.invalidateFilter()
+
+    def setMetaPVFilters(self, filters: list[dict]) -> None:
+        """Set the filters that will be applied to the meta pv columns"""
+        self.filters = filters
         self.invalidateFilter()

--- a/superscore/widgets/snapshot_table.py
+++ b/superscore/widgets/snapshot_table.py
@@ -1,4 +1,5 @@
 import operator
+
 from qtpy import QtCore
 
 from superscore.model import Snapshot
@@ -95,7 +96,7 @@ class SnapshotFilterModel(QtCore.QSortFilterProxyModel):
         self.setFilterKeyColumn(1)
         self.since = QtCore.QDate.currentDate().addYears(-1)
         self.until = QtCore.QDate.currentDate()
-        self.filters = [] # List that contains: [{column, operator, value}]
+        self.filters = []  # List that contains: [{column, operator, value}]
 
     def filterAcceptsRow(self, row: int, parent: QtCore.QModelIndex) -> bool:
         datetime = self.sourceModel()._data[row].creation_time

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -16,6 +16,7 @@ import superscore.color
 from superscore.client import Client
 from superscore.control_layers._base_shim import EpicsData
 from superscore.model import Parameter, Readback, Setpoint, Snapshot
+from superscore.widgets.filter_bar import FilterBar
 from superscore.widgets.configure_window import TagGroupsWindow
 from superscore.widgets.core import NameDescTagsWidget, QtSingleton
 from superscore.widgets.date_range import DateRangeWidget
@@ -120,9 +121,16 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         search_bar.setClearButtonEnabled(True)
         search_bar.addAction(
             qta.icon("fa5s.search"),
-            QtWidgets.QLineEdit.LeadingPosition,
+            QtWidgets.QLineEdit.TrailingPosition,
         )
+        search_bar.setPlaceholderText("Search title...")
         filters_layout.addWidget(search_bar)
+
+        filter_toggle_button = QtWidgets.QPushButton(qta.icon("fa5s.filter"), "Filter  ")
+        filter_toggle_button.setLayoutDirection(QtCore.Qt.RightToLeft)  # Put the filter icon after the button text
+        filter_toggle_button.setToolTip("Show/hide meta pv filters")
+        filter_toggle_button.clicked.connect(self.toggle_filter_popup)
+        filters_layout.addWidget(filter_toggle_button)
 
         spacer = QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         filters_layout.addSpacerItem(spacer)
@@ -152,6 +160,23 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
 
         search_bar.textEdited.connect(proxy_model.setFilterFixedString)
         date_range.rangeChanged.connect(proxy_model.setDateRange)
+
+        # Set up the filters for the meta pv columns
+        meta_columns = [pv.description for pv in self.client.backend.get_meta_pvs()]
+        self.meta_pv_filter_popup = QtWidgets.QFrame(self)
+        self.meta_pv_filter_popup.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.meta_pv_filter_popup.setWindowFlags(QtCore.Qt.Popup)
+        filter_popup_layout = QtWidgets.QVBoxLayout(self.meta_pv_filter_popup)
+        filter_popup_layout.setContentsMargins(10, 10, 10, 10)
+
+        self.meta_pv_filter_bar = FilterBar(meta_columns)
+        filter_popup_layout.addWidget(self.meta_pv_filter_bar)
+
+        self.meta_pv_filter_bar.filters_updated.connect(
+            lambda: proxy_model.setMetaPVFilters(self.meta_pv_filter_bar.get_filters())
+        )
+
+        self.meta_pv_filter_popup.installEventFilter(self)
 
         return view_snapshot_page
 
@@ -195,6 +220,14 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
 
         return configure_page
 
+    def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent) -> bool:
+        """Event filter for the window for responding to events as needed."""
+        # If the filter popup is open and the user clicks out of it, close it for them
+        if watched is self.meta_pv_filter_popup and event.type() == QtCore.QEvent.MouseButtonPress:
+            if not self.meta_pv_filter_popup.rect().contains(event.pos()):
+                self.meta_pv_filter_popup.hide()
+        return super().eventFilter(watched, event)
+
     @QtCore.Slot()
     def open_pv_browser_page(self) -> None:
         """Open the PV Browser Page if it is not already open."""
@@ -232,6 +265,16 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         # Set new_snapshot in the details page
         new_snapshot = self.snapshot_table.model().sourceModel().index_to_snapshot(index)
         self.open_snapshot(new_snapshot)
+
+    def toggle_filter_popup(self) -> None:
+        """Show or hide the popup that includes the meta pv filters."""
+        if self.meta_pv_filter_popup.isVisible():
+            self.meta_pv_filter_popup.hide()
+        else:
+            button = self.sender()
+            pos = button.mapToGlobal(QtCore.QPoint(0, button.height()))
+            self.meta_pv_filter_popup.move(pos)
+            self.meta_pv_filter_popup.show()
 
     @QtCore.Slot()
     @QtCore.Slot(Snapshot)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -16,10 +16,10 @@ import superscore.color
 from superscore.client import Client
 from superscore.control_layers._base_shim import EpicsData
 from superscore.model import Parameter, Readback, Setpoint, Snapshot
-from superscore.widgets.filter_bar import FilterBar
 from superscore.widgets.configure_window import TagGroupsWindow
 from superscore.widgets.core import NameDescTagsWidget, QtSingleton
 from superscore.widgets.date_range import DateRangeWidget
+from superscore.widgets.filter_bar import FilterBar
 from superscore.widgets.page.page import Page
 from superscore.widgets.page.pv_browser import PVBrowserPage
 from superscore.widgets.page.snapshot_comparison import SnapshotComparisonPage


### PR DESCRIPTION
## Description
Updates the snapshot GUI to allow for filtering the snapshot table based on meta pv values.

Creates a widget for applying filters based on meta pv column names. Integrates with existing filtering.

Currently assumes that meta pvs are numbers that are compared with numerical operators. If strings are valid too, can easily extend that functionality and include additional operators.

## Motivation
Closes [SWAPPS-116](https://jira.slac.stanford.edu/browse/SWAPPS-116)

## Testing
Tested interactively, added a new test case to the test suite.

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
