### PR TITLE
MNT: allow opening snapshot details pages using Snapshot instance, or no instance, in addition to UUID

### DIFF
--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -127,7 +127,7 @@ class SnapshotDetailsPage(Page):
         if self.snapshot.uuid in self.pv_table_models:
             self.snapshot_details_model = self.pv_table_models[self.snapshot.uuid]
         else:
-            self.snapshot_details_model = PVTableModel(self.snapshot.uuid, self.client)
+            self.snapshot_details_model = PVTableModel(self.snapshot, self.client)
             self.pv_table_models[self.snapshot.uuid] = self.snapshot_details_model
         self.snapshot_details_table.model().setSourceModel(self.snapshot_details_model)
 

--- a/superscore/widgets/pv_table.py
+++ b/superscore/widgets/pv_table.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 from uuid import UUID
 
 from qtpy import QtCore, QtGui
@@ -59,9 +59,18 @@ class PVTableModel(LivePVTableModel):
     for selecting rows.
     """
 
-    def __init__(self, snapshot: Union[UUID, Snapshot], client, parent=None):
+    def __init__(
+        self,
+        client,
+        snapshot: Optional[Union[UUID, Snapshot]],
+        parent=None,
+    ):
         super().__init__(client=client, entries=[], parent=parent)
-        self.set_snapshot(snapshot)
+        if snapshot:
+            self.set_snapshot(snapshot)
+        else:
+            self._data = []
+            self._checked = set()
 
     def rowCount(self, parent=None):
         return len(self._data)

--- a/superscore/widgets/pv_table.py
+++ b/superscore/widgets/pv_table.py
@@ -1,11 +1,11 @@
 from enum import Enum, auto
-from typing import Iterable
+from typing import Iterable, Union
 from uuid import UUID
 
 from qtpy import QtCore, QtGui
 
 import superscore.color
-from superscore.model import Readback, Setpoint
+from superscore.model import Readback, Setpoint, Snapshot
 from superscore.widgets import SEVERITY_ICONS
 from superscore.widgets.views import LivePVTableModel
 
@@ -59,14 +59,9 @@ class PVTableModel(LivePVTableModel):
     for selecting rows.
     """
 
-    def __init__(self, snapshot_id: UUID, client, parent=None):
-        self.client = client
-        self._data = list(self.client.search(
-            ("ancestor", "eq", snapshot_id),
-            ("entry_type", "eq", (Setpoint, Readback)),
-        ))
-        self._checked = set()
-        super().__init__(client=client, entries=self._data, parent=parent)
+    def __init__(self, snapshot: Union[UUID, Snapshot], client, parent=None):
+        super().__init__(client=client, entries=[], parent=parent)
+        self.set_snapshot(snapshot)
 
     def rowCount(self, parent=None):
         return len(self._data)
@@ -199,11 +194,22 @@ class PVTableModel(LivePVTableModel):
             self.dataChanged.emit(index, index)
         return True
 
-    def set_snapshot(self, snapshot_id: UUID) -> None:
-        self._data = list(self.client.search(
-            ("ancestor", "eq", snapshot_id),
-            ("entry_type", "eq", (Setpoint, Readback)),
-        ))
+    def set_snapshot(self, snapshot: Union[UUID, Snapshot]) -> None:
+        try:
+            entries = snapshot.children
+        except AttributeError:
+            entries = list(self.client.search(
+                ("ancestor", "eq", snapshot),
+                ("entry_type", "eq", (Setpoint, Readback)),
+            ))
+        finally:
+            self._data = [
+                entry if isinstance(entry, (Setpoint, Readback)) else list(
+                    self.client.search(
+                        ("uuid", "eq", entry)
+                    )
+                )[0] for entry in entries
+            ]
         self._checked = set()
         self.set_entries(self._data)
 


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* Support passing `Snapshot` instance to `PVTableModel`, fetching children as needed
* Support opening snapshot details page without specifying any snapshot
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Opening a page without specifying any snapshot is necessary for launching the app with a backend that doesn't have any snapshots yet.

Being able to initialize `PVTableModel`s using an instance rather than a UUID helps with displaying snapshots that are recently created but not yet in the backend.  It can also help reduce network usage.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
