### PR TITLE
BUG: get PVs to restore from PVTableModel rather than proxy model

### DIFF
--- a/superscore/widgets/page/snapshot_details.py
+++ b/superscore/widgets/page/snapshot_details.py
@@ -173,7 +173,7 @@ class SnapshotDetailsPage(Page):
         dialog.layout().addWidget(button_box)
         button_box.accepted.connect(dialog.accept)
         button_box.rejected.connect(dialog.reject)
-        selected_pvs = self.snapshot_details_table.model().get_selected_pvs()
+        selected_pvs = self.snapshot_details_model.get_selected_pvs()
         if len(selected_pvs) == 0:
             dialog.setWindowTitle("Restore all PVs?")
         else:


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* call `snapshot_details_model.get_selected_pvs()` rather than `snapshot_details_table.model().get_selected_pvs()` to access `PVTableModel` rather than proxy model
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an error when attempting to restore PVs
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
