### PR TITLE
BUG: Fix PVBrowser TagWidget vertical size allocation

### DIFF
--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -202,6 +202,9 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.main_content_stack.setCurrentWidget(self.pv_browser_page)
             self.navigation_panel.set_nav_button_selected(self.navigation_panel.browse_pvs_button)
 
+            # Fixes TagWidget vertical size allocation
+            self.pv_browser_page.pv_browser_table.resizeRowsToContents()
+
     @QtCore.Slot()
     def open_view_snapshot_page(self) -> None:
         """Open the snapshot page if it is not already open."""


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->

Adds a resizeRowsToContents() call to correctly set the expected size for rows in the PV Browser table. 

There is a line in PVBrowserPage which resizes the columns:

https://github.com/slaclab/superscore/blob/b6717b4f4dcb17844b30614e561aedc3da4792dc/superscore/widgets/page/pv_browser.py#L57

Putting the row resize there didn't work - seems like it has to be called after the page is set as the current widget.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes bug where too much vertical space was allocated to each row in the PV Browser Table.

[SWAPPS-275](https://jira.slac.stanford.edu/browse/SWAPPS-275)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Added a comment in the code to explain why it's there.

## Screenshots


https://github.com/user-attachments/assets/036a9295-71d5-4add-8738-8b15b1871f72



## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
