### PR TITLE
BUG: support middle-click copy with PySide6

### DIFF
--- a/superscore/widgets/squirrel_table_view.py
+++ b/superscore/widgets/squirrel_table_view.py
@@ -21,9 +21,9 @@ class SquirrelTableView(QtWidgets.QTableView):
         text = self.model().data(index, QtCore.Qt.ToolTipRole)
         clipboard = QtWidgets.QApplication.clipboard()
         if clipboard.supportsSelection():
-            mode = clipboard.Selection
+            mode = clipboard.Mode.Selection
         else:
-            mode = clipboard.Clipboard
+            mode = clipboard.Mode.Clipboard
         clipboard.setText(text, mode=mode)
 
 


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* access clipboard selection mode through a PySide6 enum
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows user to copy strings via mouse middle-click
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
