### PR TITLE
BUG: open correct snapshot when snapshot table has filters applied

### DIFF
--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -244,7 +244,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             self.navigation_panel.set_nav_button_selected(self.navigation_panel.configure_tags_button)
 
     @QtCore.Slot(QtCore.QModelIndex)
-    def open_snapshot_index(self, index: QtCore.QModelIndex) -> None:
+    def open_snapshot_index(self, proxy_index: QtCore.QModelIndex) -> None:
         """
         Opens the snapshot stored at the selected index. A widget representing the
         snapshot is created if necessary and set as the current view in the stack.
@@ -252,13 +252,14 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         Args:
             index (QtCore.Qt.QModelIndex): table index of the snapshot to open
         """
-        if not index.isValid():
+        if not proxy_index.isValid():
             logger.warning("Invalid index passed to open_snapshot_details")
             return
 
         # Set new_snapshot in the details page
-        new_snapshot = self.snapshot_table.model().sourceModel().index_to_snapshot(index)
-        self.open_snapshot(new_snapshot)
+        source_index = self.snapshot_table.model().mapToSource(proxy_index)
+        to_open = self.snapshot_table.model().sourceModel().index_to_snapshot(source_index)
+        self.open_snapshot(to_open)
 
     def toggle_filter_popup(self) -> None:
         """Show or hide the popup that includes the meta pv filters."""


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* map index from snapshot proxy model to source model before opening
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When filters are applied to the snapshot table, attempting to open a snapshot via double-click opens the incorrect snapshot. Mapping the proxy index to the source index before opening fixes this bug.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
