### PR TITLE
ENH: implement importing PVs from a file

### DIFF
--- a/docs/source/import_format.rst
+++ b/docs/source/import_format.rst
@@ -1,0 +1,34 @@
+Importing PVs
+=============
+PVs can be added in batches by importing them from a csv file.
+
+Instructions
+------------
+
+From the "Browse PVs" page, click the "Import PVs" button and select the file you would like to import.
+A pop-up will preview the parsed PVs, from which you can cancel or continue the import. If the backend
+fails to import any PV, the entire batch will fail so that the file can be adjusted and re-tried. Due
+to backend constraints, avoid importing more than 1000 PVs at a time.
+
+Format
+------
+
+The csv file must have the header:
+
+.. code-block::
+
+   Setpoint,Readback,[Description,]{Tag Group 1},{Tag Group 2},...
+
+The setpoint and readback columns can't both be empty for a given row. The description column is optional.
+In the header, each column after readback / description is the name of a tag group; in each row, the data
+in each column are tags within that group. Tags can be specified as a single name, or as a comma-separated
+list of names within double-quotes.
+
+For example, the following valid csv exhibits PVs with different combinations of data:
+
+.. code-block::
+
+   Setpoint,Readback,Region,Area,Subsystem
+   FBCK:BCI0:1:CHRGSP,FBCK:BCI0:1:CHRG,"Feedback-All","SETPOINTS","FBCK"
+   ACCL:LI24:100:KLY_C_1_TCTL,,"Klystron Phases and Timing,Timing-All","LI24","Timing,Klystron Timing"
+   ,BPMS:LI30:801:X,"BSA,BSA-CUHXR,BSA-CUSXR","LI30","BPMS"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,12 @@ Welcome to superscore's documentation!
 
 .. toctree::
    :maxdepth: 2
+   :caption: User Documentation
+
+   import_format.rst
+
+.. toctree::
+   :maxdepth: 2
    :caption: Developer Documentation
 
    widgets/index.rst

--- a/superscore/backends/mongo.py
+++ b/superscore/backends/mongo.py
@@ -314,7 +314,9 @@ class MongoBackend(_Backend):
         for pv in pvs:
             body.append(
                 {
-                    "setpointAddress": pv.setpoint,
+                    "setpointAddress": pv.setpoint or None,
+                    "readbackAddress": pv.readback or None,
+                    "configAddress": pv.config or None,
                     "description": pv.description,
                     "absTolerance": pv.abs_tolerance,
                     "relTolerance": pv.rel_tolerance,

--- a/superscore/backends/mongo.py
+++ b/superscore/backends/mongo.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 ENDPOINTS = {
     "TAGS": "/v1/tags",
     "PVS": "/v1/pvs",
+    "PVS_MULTI": "/v1/pvs/multi",
     "SNAPSHOTS": "/v1/snapshots",
 }
 
@@ -307,6 +308,24 @@ class MongoBackend(_Backend):
         self._raise_for_status(r)
         pv_dict = r.json()["payload"]
         return self._unpack_pv(pv_dict)
+
+    def add_multiple_pvs(self, pvs: Iterable[PV]) -> Iterable[PV]:
+        body = []
+        for pv in pvs:
+            body.append(
+                {
+                    "setpointAddress": pv.setpoint,
+                    "description": pv.description,
+                    "absTolerance": pv.abs_tolerance,
+                    "relTolerance": pv.rel_tolerance,
+                    "tags": self._pack_tags(pv.tags),
+                }
+            )
+        r = requests.post(self.address + ENDPOINTS["PVS_MULTI"], json=body)
+        logger.debug(f"{r.request.method} {r.url} with response {r.status_code} ({r.reason})")
+        self._raise_for_status(r)
+        pv_dicts = r.json()["payload"]
+        return [self._unpack_pv(pv_dict) for pv_dict in pv_dicts]
 
     def update_pv(self, pv_id, setpoint="", description="", tags=None, abs_tolerance=None, rel_tolerance=None) -> None:
         """

--- a/superscore/tests/test_utils.py
+++ b/superscore/tests/test_utils.py
@@ -1,0 +1,81 @@
+import csv
+
+import pytest
+
+from superscore.utils import parse_csv_to_dict
+
+
+def write_csv(tmp_path, headers, rows, name="input.csv"):
+    """Create a test csv file and return the path to it. Will automatically clean itself up after the test is run."""
+    file_path = tmp_path / name
+    with file_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        writer.writerows(rows)
+    return file_path
+
+
+def test_parse_correctly_formatted_csv_file(tmp_path):
+    """Verify that a csv file in the correct format is parsed correctly"""
+
+    # Mimic a csv file that looks like:
+    # PV,Description,Area,Subsystem
+    # LASR:GUNB:TEST1,First LASR pv in GUNB,IN20, GUNB,Laser
+    # MGNT:GUNB:TEST0,Only MGNT pv in GUNB,IN20,Magnet
+
+    headers = ["PV", "Description", "Area", "Subsystem"]
+    rows = [
+        ["LASR:GUNB:TEST1", "First LASR pv in GUNB", "IN20, GUNB", "Laser"],
+        ["MGNT:GUNB:TEST0", "Only MGNT pv in GUNB", "IN20", "Magnet"],
+    ]
+    path = write_csv(tmp_path, headers, rows)
+
+    # Parse the temporary csv file and confirm everything looks ok
+    output = parse_csv_to_dict(str(path))
+    assert len(output) == 2
+
+    first_row = output[0]
+    assert first_row["PV"] == "LASR:GUNB:TEST1"
+    assert first_row["Description"] == "First LASR pv in GUNB"
+    assert first_row["groups"]["Area"] == ["IN20", "GUNB"]
+    assert first_row["groups"]["Subsystem"] == ["Laser"]
+
+    second_row = output[1]
+    assert second_row["PV"] == "MGNT:GUNB:TEST0"
+    assert second_row["Description"] == "Only MGNT pv in GUNB"
+    assert second_row["groups"]["Area"] == ["IN20"]
+    assert second_row["groups"]["Subsystem"] == ["Magnet"]
+
+
+def test_parse_csv_without_required_columns(tmp_path):
+    """Ensure the correct errors are raised when required columns are missing"""
+    # Missing PV
+    headers = ["Description", "Area"]
+    rows = [["Test description", "IN20"]]
+    path = write_csv(tmp_path, headers, rows)
+    with pytest.raises(ValueError) as e:
+        parse_csv_to_dict(str(path))
+    assert "No 'PV' column" in str(e.value)
+
+    # Missing Description
+    headers2 = ["PV", "Area"]
+    rows = [["TEST:PV", "IN20"]]
+    path = write_csv(tmp_path, headers2, rows, name="input2.csv")
+    with pytest.raises(ValueError) as e:
+        parse_csv_to_dict(str(path))
+    assert "No 'Description' column" in str(e.value)
+
+
+def test_parse_csv_with_missing_or_bad_data(tmp_path):
+    """When non-required data is missing or invalid, ensured it is handled correctly"""
+    headers = ["PV", "Description", "Value1", "Value2", "Value3"]
+    rows = [["TEST:PV", "Test description", "NaN", "none", ""]]
+    path = write_csv(tmp_path, headers, rows)
+    output = parse_csv_to_dict(str(path))
+    parsed_row = output[0]
+
+    assert parsed_row["PV"] == "TEST:PV"
+    assert parsed_row["Description"] == "Test description"
+    assert parsed_row["groups"]["Value1"] == []
+    assert parsed_row["groups"]["Value2"] == []
+    assert parsed_row["groups"]["Value3"] == []

--- a/superscore/utils.py
+++ b/superscore/utils.py
@@ -1,6 +1,8 @@
+import csv
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Dict, List
 
 SUPERSCORE_SOURCE_PATH = Path(__file__).parent
 
@@ -27,3 +29,41 @@ def build_abs_path(basedir: str, path: str) -> str:
     if not os.path.isabs(path):
         return os.path.abspath(os.path.join(basedir, path))
     return path
+
+
+def parse_csv_to_dict(csv_file_path: str) -> List[Dict[str, Any]]:
+    """
+    Parse CSV file representing PV data into a form that can be bulk-imported by the backend. Each row represents
+    a PV and its associated meta-data.
+    """
+    result = []
+    with open(csv_file_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        cleaned_headers = [h.strip() for h in reader.fieldnames if h and h.strip()]
+
+        group_columns = [col for col in cleaned_headers if col not in ['Setpoint', 'Readback', 'Description']]
+
+        for row_num, row in enumerate(reader, start=2):
+            setpoint = row.get('Setpoint', '').strip()
+            readback = row.get('Readback', '').strip()
+            if not (setpoint or readback):
+                continue
+            desc_value = row.get('Description', '').strip()
+
+            row_dict = {
+                'Setpoint': setpoint,
+                'Readback': readback,
+                'Description': desc_value,
+                'groups': {}
+            }
+
+            for group_name in group_columns:
+                cell_value = row.get(group_name, '').strip()
+                if cell_value and cell_value.lower() not in ['nan', 'none']:
+                    values = [val.strip() for val in cell_value.split(',') if val.strip()]
+                    row_dict['groups'][group_name] = values
+                else:
+                    row_dict['groups'][group_name] = []
+
+            result.append(row_dict)
+    return result

--- a/superscore/widgets/page/pv_browser.py
+++ b/superscore/widgets/page/pv_browser.py
@@ -1,14 +1,22 @@
+import logging
+from typing import Any, Dict, List
+
 import qtawesome as qta
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from superscore.client import Client
+from superscore.model import PV
 from superscore.permission_manager import PermissionManager
+from superscore.utils import parse_csv_to_dict
 from superscore.widgets.page.page import Page
 from superscore.widgets.pv_browser_table import (PV_BROWSER_HEADER,
+                                                 CSVTableModel,
                                                  PVBrowserFilterProxyModel,
                                                  PVBrowserTableModel)
 from superscore.widgets.squirrel_table_view import SquirrelTableView
 from superscore.widgets.tag import TagDelegate, TagsWidget
+
+logger = logging.getLogger(__file__)
 
 
 class PVBrowserPage(Page):
@@ -19,14 +27,13 @@ class PVBrowserPage(Page):
     def __init__(self, client: Client, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
         self.client = client
-
         self.setup_ui()
 
     def setup_ui(self):
         """Initialize the PV browser page with the PV browser table."""
 
         pv_browser_layout = QtWidgets.QVBoxLayout()
-        pv_browser_layout.setContentsMargins(0, 11, 0, 0)
+        pv_browser_layout.setContentsMargins(0, 11, 11, 0)
         self.setLayout(pv_browser_layout)
 
         self.search_bar = QtWidgets.QLineEdit(self)
@@ -43,12 +50,19 @@ class PVBrowserPage(Page):
         self.add_pv_button.setObjectName("add-pv-btn")
         self.add_pv_button.clicked.connect(self.sigAddPV)
 
+        self.import_pvs = QtWidgets.QPushButton("Import PVs")
+        self.import_pvs.setObjectName("import-pv-btn")
+        self.import_pvs.clicked.connect(self.select_file)
+
+        search_bar_lyt = QtWidgets.QHBoxLayout()
         spacer = QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
 
         search_bar_lyt = QtWidgets.QHBoxLayout()
         search_bar_lyt.addWidget(self.search_bar)
         search_bar_lyt.addSpacerItem(spacer)
         search_bar_lyt.addWidget(self.add_pv_button)
+        search_bar_lyt.addWidget(self.import_pvs)
+
         pv_browser_layout.addLayout(search_bar_lyt)
 
         filter_tags = TagsWidget(tag_groups=self.client.backend.get_tags(), enabled=True)
@@ -78,8 +92,10 @@ class PVBrowserPage(Page):
         permission_manager = PermissionManager.get_instance()
         if not permission_manager.is_admin():
             self.add_pv_button.hide()
+            self.import_pvs.hide()
             self.pv_browser_table.setColumnHidden(PV_BROWSER_HEADER.DELETE.value, True)
         permission_manager.admin_status_changed.connect(self.add_pv_button.setVisible)
+        permission_manager.admin_status_changed.connect(self.import_pvs.setVisible)
         permission_manager.admin_status_changed.connect(
             lambda is_admin: self.pv_browser_table.setColumnHidden(
                 PV_BROWSER_HEADER.DELETE.value,
@@ -96,6 +112,13 @@ class PVBrowserPage(Page):
                 border-radius: 4px;
                 text-align: left;
             }
+            QPushButton#import-pv-btn {
+                border: 1px solid #555555;
+                background-color: white;
+            }
+            QPushButton#import-pv-btn:hover {
+                background-color: lightgray;
+            }
             QPushButton#add-pv-btn {
                 border: 1px solid #555555;
                 background-color: white;
@@ -111,6 +134,25 @@ class PVBrowserPage(Page):
         if index.column() == PV_BROWSER_HEADER.DELETE.value:
             self.pv_browser_table.model().sourceModel().removeRow(index.row())
 
+    def select_file(self) -> None:
+        """Open file dialog to select CSV file"""
+        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select CSV File",
+            "",
+            "CSV Files (*.csv);;All Files (*)"
+        )
+
+        if file_path:
+            self.csv_file_path = file_path
+            self.csv_data = parse_csv_to_dict(self.csv_file_path)
+            self.show_table()
+
+    def show_table(self) -> None:
+        """Show the parsed cvs data in a table dialog"""
+        dialog = CSVTableDialog(self.csv_data, self)
+        dialog.exec_()
+
     @QtCore.Slot()
     def search_bar_middle_man(self):
         search_text = self.search_bar.text()
@@ -121,3 +163,290 @@ class PVBrowserPage(Page):
         if not isinstance(index, QtCore.QModelIndex) or not index.isValid():
             return
         self.sigOpenPVDetails.emit(index, self.pv_browser_table)
+
+    def refresh_table(self):
+        """Refresh the PV browser table after import"""
+        source_model = self.pv_browser_filter.sourceModel()
+        if hasattr(source_model, 'refresh'):
+            source_model.refresh()
+        elif hasattr(source_model, 'layoutChanged'):
+            source_model.layoutChanged.emit()
+
+
+class CSVTableDialog(QtWidgets.QDialog):
+    def __init__(self, csv_data: List[Dict[str, Any]], parent=None):
+        super().__init__(parent)
+        self.csv_data = csv_data
+        self.parent_page = parent
+        self.init_ui()
+
+    def init_ui(self):
+        self.setWindowTitle("CSV Data Table")
+        self.setGeometry(200, 200, 1200, 600)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        info_label = QtWidgets.QLabel(f"Displaying {len(self.csv_data)} rows of CSV data")
+        info_label.setFont(QtGui.QFont("Arial", 10, QtGui.QFont.Bold))
+        layout.addWidget(info_label)
+
+        backend_tag_def = {}
+        if self.parent_page and hasattr(self.parent_page, 'client'):
+            backend_tag_def = self.parent_page.client.backend.get_tags()
+
+        self.model = CSVTableModel(self.csv_data, backend_tag_def)
+
+        validation_results = self.model.get_validation_results()
+        self._show_validation_feedback(layout, validation_results)
+
+        self.table_view = QtWidgets.QTableView()
+        self.table_view.setModel(self.model)
+
+        tags_column_index = self.model._build_headers().index('Tags')
+        tag_delegate = TagDelegate(self.model.tag_def, self.table_view)
+        self.table_view.setItemDelegateForColumn(tags_column_index, tag_delegate)
+
+        self.table_view.setAlternatingRowColors(True)
+        self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
+        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.verticalHeader().setVisible(False)
+        self.table_view.resizeColumnsToContents()
+
+        layout.addWidget(self.table_view)
+
+        button_layout = QtWidgets.QHBoxLayout()
+
+        import_all_btn = QtWidgets.QPushButton("Import Data")
+        import_all_btn.clicked.connect(self.import_data)
+        button_layout.addWidget(import_all_btn)
+
+        cancel_btn = QtWidgets.QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        button_layout.addWidget(cancel_btn)
+
+        layout.addLayout(button_layout)
+
+    def import_data(self) -> None:
+        """Import all data into backend"""
+        if not self.csv_data:
+            QtWidgets.QMessageBox.warning(self, "Warning", "No data to import.")
+            return
+
+        try:
+            success_count, error_count, errors = self._import_rows(self.csv_data)
+            self._show_import_results(success_count, error_count, errors, len(self.csv_data))
+
+            if success_count > 0:
+                self.accept()
+        except Exception as e:
+            QtWidgets.QMessageBox.critical(self, "Import Error", f"Failed to import all data: {str(e)}")
+            print(f"Import failed: {e}")
+
+    def _import_rows(self, rows_to_import: List[Dict[str, Any]]) -> tuple:
+        """
+        Import rows into the backend.
+        Returns: (success_count, error_count, error_list)
+        """
+        parameters = []
+
+        for row_data in rows_to_import:
+            parameter = self._create_parameter_from_row(row_data)
+            parameters.append(parameter)
+
+        parent = getattr(self, "parent_page", None)
+        client = getattr(parent, "client", None)
+        backend = getattr(client, "backend", None)
+        if backend is None:
+            return 0, len(rows_to_import), ["No client connection available"]
+
+        pvs_from_backend = []
+        try:
+            pvs_from_backend = backend.add_multiple_pvs(parameters)
+        except Exception as e:
+            print(f"Failed to import rows: {str(e)}")
+            return 0, len(rows_to_import), [str(e)]
+
+        try:
+            parent.pv_browser_table.model().sourceModel().add_pvs(pvs_from_backend)
+        except TypeError as e:
+            logger.exception(e)
+            logger.exception("Can't add imported PVs to PV browser table")
+
+        return len(rows_to_import), 0, []
+
+    def _create_parameter_from_row(self, row_data: Dict[str, Any]):
+        """Create a PV object from CSV row data with proper tag handling"""
+        setpoint = row_data['Setpoint']
+        readback = row_data['Readback']
+        description = row_data['Description']
+        csv_groups = row_data['groups']
+
+        tag_def = {}
+        if self.parent_page and hasattr(self.parent_page, 'client'):
+            tag_def = self.parent_page.client.backend.get_tags()
+
+        tagset = self._create_tag_mapping_from_csv(csv_groups, tag_def)
+
+        pv = PV(
+            setpoint=setpoint,
+            readback=readback,
+            description=description,
+            tags=tagset,
+        )
+
+        return pv
+
+    def _create_tag_mapping_from_csv(self, csv_groups: Dict[str, List[str]], tag_def: Dict) -> Dict[int, set]:
+        """
+        Create a mapping from CSV groups to your tag system.
+        """
+        tagset = {}
+
+        for tag_group_id, (group_name, desc, choices) in tag_def.items():
+            csv_values = csv_groups.get(group_name, [])
+            tag_ids = set()
+
+            for tag_id, tag_name in choices.items():
+                if tag_name in csv_values:
+                    tag_ids.add(tag_id)
+
+            tagset[tag_group_id] = tag_ids
+
+        return tagset
+
+    def _show_import_results(self, success_count: int, error_count: int, errors: List[str], total_attempted: int):
+        """Show import results to user"""
+        if error_count == 0:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Import Successful",
+                f"Successfully imported all {success_count} entries."
+            )
+        elif success_count == 0:
+            error_details = "\n".join(errors[:3])
+            if len(errors) > 3:
+                error_details += f"\n... and {len(errors) - 3} more errors"
+
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Import Failed",
+                f"Failed to import any entries.\n\n"
+                f"Error:\n{error_details}"
+            )
+        else:
+            error_details = "\n".join(errors[:3])
+            if len(errors) > 3:
+                error_details += f"\n... and {len(errors) - 3} more errors"
+
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Import Completed with Errors",
+                f"Import Results:\n"
+                f"• Successfully imported: {success_count}\n"
+                f"• Failed: {error_count}\n"
+                f"• Total attempted: {total_attempted}\n\n"
+                f"First few errors:\n{error_details}"
+            )
+
+    def _show_validation_feedback(self, layout, validation_results):
+        """Show detailed validation feedback to user"""
+        rejected_groups = validation_results['rejected_groups']
+        rejected_values = validation_results['rejected_values']
+
+        if rejected_groups or rejected_values:
+            validation_group = QtWidgets.QGroupBox("Validation Results")
+            validation_group.setStyleSheet("QGroupBox { color: orange; font-weight: bold; }")
+            validation_layout = QtWidgets.QVBoxLayout(validation_group)
+
+            if rejected_groups:
+                group_label = QtWidgets.QLabel(
+                    f"Rejected Groups (not found in backend): {', '.join(rejected_groups)}"
+                )
+                group_label.setStyleSheet("color: red; padding: 2px;")
+                group_label.setWordWrap(True)
+                validation_layout.addWidget(group_label)
+
+            if rejected_values:
+                values_label = QtWidgets.QLabel("Rejected Values:")
+                values_label.setStyleSheet("color: red; padding: 2px;")
+                validation_layout.addWidget(values_label)
+
+                for group_name, rejected_vals in rejected_values.items():
+                    val_detail = QtWidgets.QLabel(
+                        f"   • {group_name}: {', '.join(sorted(rejected_vals))}"
+                    )
+                    val_detail.setStyleSheet("color: red; padding-left: 10px;")
+                    val_detail.setWordWrap(True)
+                    validation_layout.addWidget(val_detail)
+
+            if self.model.tag_def:
+                available_label = QtWidgets.QLabel("Available Backend Options:")
+                available_label.setStyleSheet("color: green; font-weight: bold; padding: 2px;")
+                validation_layout.addWidget(available_label)
+
+                for tag_group_id, (group_name, desc, choices) in self.model.tag_def.items():
+                    option_detail = QtWidgets.QLabel(
+                        f"   • {group_name}: {', '.join(sorted(choices.values()))}"
+                    )
+                    option_detail.setStyleSheet("color: green; padding-left: 10px;")
+                    option_detail.setWordWrap(True)
+                    validation_layout.addWidget(option_detail)
+
+            layout.addWidget(validation_group)
+
+
+class TagMappingDialog(QtWidgets.QDialog):
+    """Dialog to help users map CSV groups to existing tag groups"""
+
+    def __init__(self, csv_groups: List[str], tag_def: Dict, parent=None):
+        super().__init__(parent)
+        self.csv_groups = csv_groups
+        self.tag_def = tag_def
+        self.mappings = {}
+        self.init_ui()
+
+    def init_ui(self):
+        self.setWindowTitle("Map CSV Groups to Tags")
+        self.setGeometry(300, 300, 500, 400)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        label = QtWidgets.QLabel("Map your CSV groups to existing tag groups:")
+        layout.addWidget(label)
+
+        self.mapping_widgets = {}
+        for csv_group in self.csv_groups:
+            group_layout = QtWidgets.QHBoxLayout()
+
+            csv_label = QtWidgets.QLabel(f"'{csv_group}' →")
+            csv_label.setFixedWidth(150)
+            group_layout.addWidget(csv_label)
+
+            combo = QtWidgets.QComboBox()
+            combo.addItem("(Skip this group)")
+            for tag_group_id, (group_name, desc, choices) in self.tag_def.items():
+                combo.addItem(group_name, tag_group_id)
+
+            group_layout.addWidget(combo)
+            layout.addLayout(group_layout)
+
+            self.mapping_widgets[csv_group] = combo
+
+        button_layout = QtWidgets.QHBoxLayout()
+        ok_button = QtWidgets.QPushButton("OK")
+        ok_button.clicked.connect(self.accept)
+        cancel_button = QtWidgets.QPushButton("Cancel")
+        cancel_button.clicked.connect(self.reject)
+
+        button_layout.addWidget(ok_button)
+        button_layout.addWidget(cancel_button)
+        layout.addLayout(button_layout)
+
+    def get_mappings(self) -> Dict[str, int]:
+        """Return the selected mappings"""
+        mappings = {}
+        for csv_group, combo in self.mapping_widgets.items():
+            tag_group_id = combo.currentData()
+            if tag_group_id is not None:
+                mappings[csv_group] = tag_group_id
+        return mappings

--- a/superscore/widgets/pv_browser_table.py
+++ b/superscore/widgets/pv_browser_table.py
@@ -102,7 +102,7 @@ class PVBrowserTableModel(QtCore.QAbstractTableModel):
 
     def add_pvs(self, pvs: Iterable[PV]):
         start = len(self._data)
-        self.beginInsertRows(QtCore.QModelIndex(), start, len(pvs))
+        self.beginInsertRows(QtCore.QModelIndex(), start, start + len(pvs) - 1)
         self._data.extend(pvs)
         self.endInsertRows()
 

--- a/superscore/widgets/pv_browser_table.py
+++ b/superscore/widgets/pv_browser_table.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum, auto
-from typing import Any
+from typing import Any, Dict, Iterable, List
 
 import qtawesome as qta
 from qtpy import QtCore
@@ -100,6 +100,12 @@ class PVBrowserTableModel(QtCore.QAbstractTableModel):
         self._data.append(pv)
         self.endInsertRows()
 
+    def add_pvs(self, pvs: Iterable[PV]):
+        start = len(self._data)
+        self.beginInsertRows(QtCore.QModelIndex(), start, len(pvs))
+        self._data.extend(pvs)
+        self.endInsertRows()
+
     def removeRow(self, row, parent=None):
         index = self.index(row, PV_BROWSER_HEADER.PV.value)
         pv = self.data(index, QtCore.Qt.UserRole)
@@ -174,3 +180,158 @@ class PVBrowserFilterProxyModel(QtCore.QSortFilterProxyModel):
 
         search_accepts_row = super().filterAcceptsRow(source_row, source_parent)
         return self.is_tag_subset(entry.tags) and search_accepts_row
+
+
+class CSVTableModel(QtCore.QAbstractTableModel):
+    def __init__(self, csv_data: List[Dict[str, Any]], backend_tag_def=None, parent=None):
+        super().__init__(parent=parent)
+        self._data = csv_data
+        self.backend_tag_def = backend_tag_def or {}
+        self.tag_def = self._filter_to_existing_backend_groups()
+        self._headers = self._build_headers()
+
+        self.rejected_groups = []
+        self.rejected_values = {}
+        self.validation_summary = self._create_validation_summary()
+
+    def _build_headers(self) -> List[str]:
+        """Build headers from the first row of data"""
+        if not self._data:
+            return []
+        headers = ['Setpoint', 'Readback', 'Description', 'Tags']
+        return headers
+
+    def rowCount(self, parent=QtCore.QModelIndex()) -> int:
+        return len(self._data)
+
+    def columnCount(self, parent=QtCore.QModelIndex()) -> int:
+        return len(self._headers)
+
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = QtCore.Qt.DisplayRole):
+        if orientation == QtCore.Qt.Horizontal and role == QtCore.Qt.DisplayRole:
+            if 0 <= section < len(self._headers):
+                return self._headers[section]
+        return None
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole):
+        if not index.isValid() or not (0 <= index.row() < len(self._data)):
+            return None
+
+        row_data = self._data[index.row()]
+        column_name = self._headers[index.column()]
+
+        if role == QtCore.Qt.DisplayRole:
+            if column_name == 'Setpoint':
+                return row_data.get('Setpoint', '')
+            elif column_name == 'Readback':
+                return row_data.get('Readback', '')
+            elif column_name == 'Description':
+                return row_data.get('Description', '')
+            elif column_name == 'Tags':
+                return self._convert_groups_to_tagset(row_data.get('groups', {}))
+        elif role == QtCore.Qt.ToolTipRole:
+            if column_name == 'Setpoint':
+                return f"Setpoint: {row_data.get('Setpoint', '')}"
+            elif column_name == 'Readback':
+                return f"Readback: {row_data.get('Readback', '')}"
+            elif column_name == 'Description':
+                return f"Description: {row_data.get('Description', '')}"
+            elif column_name == 'Tags':
+                groups = row_data.get('groups', {})
+                tooltip_text = "Tags:\n"
+                for group_name, values in groups.items():
+                    if values:
+                        tooltip_text += f"{group_name}: {', '.join(values)}\n"
+                return tooltip_text.strip()
+        elif role == QtCore.Qt.UserRole:
+            return row_data
+
+        return None
+
+    def _filter_to_existing_backend_groups(self) -> Dict:
+        """Only include CSV groups that exist in backend"""
+        if not self._data or not self.backend_tag_def:
+            return {}
+
+        csv_groups = {}
+        for row in self._data:
+            for group_name, values in row.get('groups', {}).items():
+                if group_name not in csv_groups:
+                    csv_groups[group_name] = set()
+                csv_groups[group_name].update(values)
+
+        backend_group_names = {details[0]: tag_group_id for tag_group_id, details in self.backend_tag_def.items()}
+
+        filtered_tag_def = {}
+        self.rejected_groups = []
+
+        for csv_group_name in csv_groups.keys():
+            if csv_group_name in backend_group_names:
+                backend_id = backend_group_names[csv_group_name]
+                filtered_tag_def[backend_id] = self.backend_tag_def[backend_id]
+                logger.debug(f"Accepted CSV group '{csv_group_name}' -> backend group_id {backend_id}")
+            else:
+                self.rejected_groups.append(csv_group_name)
+                logger.warn(f"Rejected CSV group '{csv_group_name}' - not found in backend")
+
+        return filtered_tag_def
+
+    def _convert_groups_to_tagset(self, csv_groups: Dict[str, List[str]]) -> Dict[int, set]:
+        """Convert CSV groups to TagSet format with value-level validation"""
+        tagset = {}
+        row_rejected_values = {}
+
+        for tag_group_id, (group_name, desc, choices) in self.tag_def.items():
+            csv_group_values = csv_groups.get(group_name, [])
+            tag_ids = set()
+            rejected_values_for_group = []
+
+            backend_values = set(choices.values())
+
+            # Validate each CSV value against backend choices
+            for csv_value in csv_group_values:
+                if csv_value in backend_values:
+                    for tag_id, tag_name in choices.items():
+                        if tag_name == csv_value:
+                            tag_ids.add(tag_id)
+                            logger.debug(f"Accepted value '{csv_value}' -> tag_id {tag_id}")
+                            break
+                else:
+                    rejected_values_for_group.append(csv_value)
+                    logger.warn(f"Rejected value '{csv_value}' (not in backend choices)")
+
+            if rejected_values_for_group:
+                if group_name not in self.rejected_values:
+                    self.rejected_values[group_name] = set()
+                self.rejected_values[group_name].update(rejected_values_for_group)
+                row_rejected_values[group_name] = rejected_values_for_group
+
+            tagset[tag_group_id] = tag_ids
+
+        if row_rejected_values:
+            logger.debug(f"Row rejected values: {row_rejected_values}")
+
+        return tagset
+
+    def _create_validation_summary(self) -> str:
+        """Create a summary of validation results"""
+        summary_parts = []
+
+        if self.rejected_groups:
+            summary_parts.append(f"Rejected groups: {', '.join(self.rejected_groups)}")
+
+        if self.rejected_values:
+            value_parts = []
+            for group_name, rejected_vals in self.rejected_values.items():
+                value_parts.append(f"{group_name}: {', '.join(sorted(rejected_vals))}")
+            summary_parts.append(f"Rejected values: {' | '.join(value_parts)}")
+
+        return " • ".join(summary_parts) if summary_parts else "All groups and values are valid"
+
+    def get_validation_results(self) -> Dict:
+        """Return comprehensive validation results"""
+        return {
+            'rejected_groups': self.rejected_groups,
+            'rejected_values': dict(self.rejected_values),
+            'summary': self.validation_summary
+        }

--- a/superscore/widgets/tag.py
+++ b/superscore/widgets/tag.py
@@ -311,7 +311,9 @@ class TagsWidget(QtWidgets.QWidget):
         return None
 
     def paint(self, painter):
-        painter.translate(self.layout().itemAt(0).widget().pos())
+        first_item = self.layout().itemAt(0)
+        if first_item:  # will be None if widget doesn't have any active tags
+            painter.translate(first_item.widget().pos())
         for i in range(self.layout().count()):
             chip = self.layout().itemAt(i).widget()
             if chip.isEnabled() or len(chip.tags) > 0:


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* add `MongoBackend.add_multiple_pvs` for atomically pushing multiple PVs to the backend at once
* add logic to parse a csv file into `PV`s
* add `Import PVs` button to PV browser page
* implement table model and view for previewing parsed PVs
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Importing PVs enables changes to be programmatic rather than manual, which improves speed, data integrity, and accountability.  If any PV cannot be added, the backend will reject the entire update, so the file used for the update will be a matching record of a successful update.

The backend requires imports to be relatively quick, so importing more than ~1000 PVs at once is currently infeasible. Importing the entire PV configuration (~36,000 PVs) took approximately 15 minutes while importing ~1000 PVs took approximately a minute.  As the backend is optimized, these times and thus the maximum import size should improve.

The csv format is:
```
Setpoint,Readback,{Tag Group 1},{Tag Group 2}, ...
```
where `{Tag Group #}` is the name of an existing tag group and the corresponding value in each row is a tag name within that group.  Multiple tags per group can be specified in a row by comma-separating the tags and wrapping the column in quotes (`""`). An example excerpt is:
```
Setpoint,Readback,Region,Area,Subsystem
FBCK:BCI0:1:CHRGSP,FBCK:BCI0:1:CHRG,Feedback-All,SETPOINTS,FBCK
,BPMS:LI30:801:X,"BSA,BSA-CUHXR,BSA-CUSXR",LI30,BPMS
```
Note the header which specifies the tag groups, the first PV has a setpoint, a readback, and one tag per group, while the second PV has a readback without a setpoint, and has 3 tags in the `Region` group.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
