### PR TITLE
DOC: add page documenting local config format

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,0 +1,26 @@
+Config
+======
+
+Local config files use the `ini format`_.
+
+.. _ini format: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
+
+Sections
+--------
+
+[backend]
+^^^^^^^^^
+
+* ``type``: which type of backend to use e.g. ``mongo``
+* ``path``: where the backend is located e.g. a URL for ``mongo`` or a filepath for ``directory``
+
+[control_layer]
+^^^^^^^^^^^^^^^
+
+* ``ca``: boolean flag for whether to use channel access protocol for accessing PVs
+* ``pva``: boolean flag for whether to use PVAccess protocol for accessing PVs
+
+[demo] (deprecated)
+^^^^^^^^^^^^^^^^^^^
+
+* ``fixtures``: a list of data sources from conftest / conftest_data to load into a test IOC during demo mode

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,12 @@ Welcome to superscore's documentation!
 ===========================================================
 
 .. toctree::
+   :maxdepth: 1
+   :caption: User Documentation
+
+   config.rst
+
+.. toctree::
    :maxdepth: 2
    :caption: Developer Documentation
 


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* add `User Documentation` section
* add `Config` page with descriptions of supported sections and options

Closes [SWAPPS-314](https://jira.slac.stanford.edu/browse/SWAPPS-314)
## Where Has This Been Documented?
`docs/source/config.rst`

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
