### PR TITLE
DOC: add page with alpha testing notes for users

### DIFF
--- a/docs/source/alpha_test.rst
+++ b/docs/source/alpha_test.rst
@@ -1,0 +1,28 @@
+Alpha Testing
+=============
+
+Accessing the Test Environment
+------------------------------
+Squirrel is available for testing from a conda environment on the ``dev-srv09`` filesystem.
+
+0. If you do not have conda installed, follow `S3DF's instructions`_.
+#. In your ``.condarc``, add ``/sdf/group/ad/eed/swapps/conda/envs`` under ``env_dirs``.
+#. Run ``conda info --envs`` to confirm ``squirrel-alpha`` is an option.
+#. Run ``conda activate squirrel-alpha`` to activate the environment, and ``conda deactivate`` to leave the environment.
+
+.. _S3DF's instructions: https://s3df.slac.stanford.edu/#/reference?id=conda
+
+Notes
+-----
+This test environment uses a shared backend, so any changes such as PVs edits
+and new snapshots will be available to other testers.
+
+To enable fetching real PV values on a dev server, source
+``/afs/slac/g/lcls/epics/setup/envSet_prodOnDev.bash``. Live values can then be disabled by
+sourcing ``/afs/slac/g/lcls/epics/setup/envSet_dev.bash`` or loading a new session.
+
+Feedback
+--------
+Bug reports and feature requests can be made by filling out `this form`_.
+
+.. _this form: https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=Wq7yzmYmFkebYOiOKuv0mhonqK7sP55ItMgN_T_cXr5URjRWWE42T0FTOElSNEk5RzhWTkRFT1pMSyQlQCN0PWcu

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to superscore's documentation!
    saving.rst
    navigating.rst
    config.rst
+   alpha_test.rst
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes [SWAPPS-338](https://jira.slac.stanford.edu/browse/SWAPPS-338)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
