### PR TITLE
MNT: cache TagsWidget per row in TagsDelegate

### DIFF
--- a/squirrel/widgets/tag.py
+++ b/squirrel/widgets/tag.py
@@ -325,16 +325,22 @@ class TagDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, tag_def, parent=None):
         super().__init__(parent)
         self.tag_def = tag_def
+        self.widgets = {}
 
     def paint(self, painter, option, index):
-        tag_widget = TagsWidget(tag_groups=self.tag_def, enabled=False)
-        tag_widget.set_tags(index.data())
+        tag_widget = self._get_tag_widget(index)
         tag_widget.layout().setGeometry(option.rect)
         tag_widget.paint(painter)
 
     def sizeHint(self, option, index):
-        tag_widget = TagsWidget(tag_groups=self.tag_def, enabled=False)
-        tag_widget.set_tags(index.data())
+        tag_widget = self._get_tag_widget(index)
         width = option.rect.width()
         height = tag_widget.heightForWidth(width)
         return QtCore.QSize(width, height)
+
+    def _get_tag_widget(self, index):
+        row = index.row()
+        if row not in self.widgets:
+            self.widgets[row] = TagsWidget(tag_groups=self.tag_def, enabled=False)
+        self.widgets[row].set_tags(index.data())
+        return self.widgets[row]


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* add cache mapping row number to `TagsWidget` instance in `TagDelegate`
* retrieve `TagsWidget` from cache during `TagDelegate.sizeHint` and `TagDelegate.paint`

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->

TagsDelegate was instantiating a new TagsWidget for each sizeHint and paint call. By caching a TagsWidget for each row, we save some runtime.

To ensure the widgets' data stays up-to-date, its tags are set each time the delegate accesses the widget. We may be able to improve performance further by reviewing this interaction.

Closes [SWAPPS-424](https://jira.slac.stanford.edu/browse/SWAPPS-424)
Related to [SWAPPS-416](https://jira.slac.stanford.edu/browse/SWAPPS-416)

## Profile
In below results, note:
* the results were obtained manually and are therefore noisy
* total time to launch reduced from `87 -> 55`
* calls to read data from the backend (`{method 'recv_into' of '_socket.socket' objects}`) reduced from `48 -> 40` but `tottime` remained comparable
* call count for `TagEditor.set_choices` reduced from `33051 -> 6015` with `tottime` reduced from `22 -> 4`
* `tottime` for `QListWidget.addItem` increased from `5 -> 14` even though the call count is much lower (`3,690,360 -> 671,340`)

```
Tue Oct  7 10:05:03 2025    profile_launch.stats

         25065112 function calls (24540339 primitive calls) in 86.600 seconds

   Ordered by: internal time
   List reduced from 4254 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    33051   21.961    0.001   35.874    0.001 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:202(set_choices)
       48   10.541    0.220   10.541    0.220 {method 'recv_into' of '_socket.socket' objects}
409558/365498    7.921    0.000    9.090    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/tables/pv_browser_table.py:62(data)
        5    5.934    1.187   70.798   14.160 {method 'resizeColumnsToContents' of 'PySide6.QtWidgets.QTableView' objects}
    33051    5.275    0.000   43.138    0.001 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:174(__init__)
  3690360    5.076    0.000    5.076    0.000 {method 'addItem' of 'PySide6.QtWidgets.QListWidget' objects}
  3690360    4.918    0.000    4.918    0.000 {method 'setData' of 'PySide6.QtWidgets.QListWidgetItem' objects}
  3690360    2.865    0.000    2.865    0.000 {method 'item' of 'PySide6.QtWidgets.QListWidget' objects}
        1    2.111    2.111    2.132    2.132 {built-in method exec}
    99206    1.447    0.000    1.447    0.000 {method 'connect' of 'PySide6.QtCore.SignalInstance' objects}
    33051    1.247    0.000   47.594    0.001 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:38(__init__)
    66105    1.161    0.000    1.161    0.000 {method 'size' of 'PySide6.QtGui.QFontMetricsF' objects}
    66105    1.048    0.000    2.501    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:118(sizeHint)
    33051    0.923    0.000    2.383    0.000 {method 'adjustSize' of 'PySide6.QtWidgets.QWidget' objects}
  3690360    0.886    0.000    0.886    0.000 {method 'count' of 'PySide6.QtWidgets.QListWidget' objects}
    44077    0.873    0.000    0.890    0.000 {method 'setLayout' of 'PySide6.QtWidgets.QWidget' objects}
    44067    0.732    0.000    0.732    0.000 {method 'setEnabled' of 'PySide6.QtWidgets.QWidget' objects}
    77021    0.680    0.000    0.680    0.000 {method 'findChildren' of 'PySide6.QtCore.QObject' objects}
    11019    0.532    0.000    2.288    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/flow_layout.py:167(doLayout)
      550    0.525    0.001    0.525    0.001 {built-in method _io.open_code}
    11016    0.469    0.000   50.510    0.005 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:238(__init__)
    33048    0.455    0.000    0.501    0.000 {method 'addWidget' of 'PySide6.QtWidgets.QLayout' objects}
    55075    0.426    0.000    1.450    0.000 {method 'data' of 'PySide6.QtCore.QModelIndex' objects}
1472049/1052541    0.380    0.000    0.530    0.000 {built-in method builtins.len}
    33098    0.372    0.000    0.372    0.000 {method 'addWidget' of 'PySide6.QtWidgets.QBoxLayout' objects}
```

```
ue Oct  7 09:59:37 2025    profile_launch_cached_tagwidgets.stats

         11801364 function calls (11276616 primitive calls) in 55.193 seconds

   Ordered by: internal time
   List reduced from 4243 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   671340   13.778    0.000   13.778    0.000 {method 'addItem' of 'PySide6.QtWidgets.QListWidget' objects}
       40   10.475    0.262   10.475    0.262 {method 'recv_into' of '_socket.socket' objects}
409558/365498    7.152    0.000    8.177    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/tables/pv_browser_table.py:62(data)
     6015    4.294    0.001   20.380    0.003 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:202(set_choices)
        5    2.824    0.565   39.408    7.882 {method 'resizeColumnsToContents' of 'PySide6.QtWidgets.QTableView' objects}
        1    2.698    2.698    2.715    2.715 {built-in method exec}
   671340    1.246    0.000    1.246    0.000 {method 'setData' of 'PySide6.QtWidgets.QListWidgetItem' objects}
     6015    1.219    0.000   21.998    0.004 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:174(__init__)
    77021    0.844    0.000    0.844    0.000 {method 'findChildren' of 'PySide6.QtCore.QObject' objects}
   671340    0.806    0.000    0.806    0.000 {method 'item' of 'PySide6.QtWidgets.QListWidget' objects}
    39034    0.548    0.000    1.213    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:118(sizeHint)
    39034    0.526    0.000    0.526    0.000 {method 'size' of 'PySide6.QtGui.QFontMetricsF' objects}
    11019    0.484    0.000    2.061    0.000 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/flow_layout.py:167(doLayout)
66012/33009    0.354    0.000    0.695    0.000 {method 'emit' of 'PySide6.QtCore.SignalInstance' objects}
1417576/998072    0.337    0.000    0.469    0.000 {built-in method builtins.len}
    55075    0.327    0.000    1.200    0.000 {method 'data' of 'PySide6.QtCore.QModelIndex' objects}
    18098    0.302    0.000    0.302    0.000 {method 'connect' of 'PySide6.QtCore.SignalInstance' objects}
   462324    0.252    0.000    0.699    0.000 /sdf/home/d/devagr/miniforge3/envs/squirrel/lib/python3.13/enum.py:695(__call__)
       12    0.245    0.020    0.245    0.020 {built-in method addApplicationFontFromData}
     6015    0.242    0.000   22.866    0.004 /sdf/home/d/devagr/src/squirrel/squirrel/widgets/tag.py:38(__init__)
   671340    0.224    0.000    0.224    0.000 {method 'count' of 'PySide6.QtWidgets.QListWidget' objects}
     8019    0.184    0.000    0.184    0.000 {method 'setEnabled' of 'PySide6.QtWidgets.QWidget' objects}
     6015    0.180    0.000    0.459    0.000 {method 'adjustSize' of 'PySide6.QtWidgets.QWidget' objects}
    88146    0.177    0.000    1.111    0.000 {method 'sizeHint' of 'PySide6.QtWidgets.QWidgetItem' objects}
     8029    0.176    0.000    0.180    0.000 {method 'setLayout' of 'PySide6.QtWidgets.QWidget' objects}
```

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
