### PR TITLE
FIX: Change `PVDetailsPopup` Fields from "PV Name" to "Setpoint Name"

### DIFF
--- a/squirrel/widgets/pv_details_components.py
+++ b/squirrel/widgets/pv_details_components.py
@@ -16,7 +16,7 @@ from squirrel.widgets.tag import TagsWidget
 class PVDetails:
     """Class to represent the details of a PV (Process Variable). Used to populate the PV details popups."""
 
-    pv_name: str
+    setpoint_name: str
     readback_name: str
     description: str
     tolerance_abs: float
@@ -157,7 +157,7 @@ class PVDetailsPopupEditable(QDialog):
 
         layout = QVBoxLayout(self)
 
-        title_text = f"Edit PV: {pv_details.pv_name}" if pv_details else "Create New PV"
+        title_text = f"Edit PV: {pv_details.setpoint_name}" if pv_details else "Create New PV"
         title_bar = PVDetailsTitleBar(title_text, self)
         layout.addWidget(title_bar)
 
@@ -178,7 +178,7 @@ class PVDetailsPopupEditable(QDialog):
         self.tolerance_rel_input.setValidator(validator)
 
         if pv_details:
-            self.setpoint_name_input.setText(pv_details.pv_name)
+            self.setpoint_name_input.setText(pv_details.setpoint_name)
             self.readback_name_input.setText(pv_details.readback_name)
             self.description_input.setText(pv_details.description)
             self.tolerance_abs_input.setText(str(pv_details.tolerance_abs))
@@ -229,7 +229,7 @@ class PVDetailsPopupEditable(QDialog):
         """Handle save button press."""
         try:
             self.pv_details = PVDetails(
-                pv_name=self.setpoint_name_input.text(),
+                setpoint_name=self.setpoint_name_input.text(),
                 readback_name=self.readback_name_input.text(),
                 description=self.description_input.text(),
                 tolerance_abs=float(self.tolerance_abs_input.text() or 0),
@@ -251,7 +251,7 @@ if __name__ == "__main__":
     tag_set = {0: {0, 2}}
 
     pv_details = PVDetails(
-        pv_name="QUAD:LI21:401:EDES",
+        setpoint_name="QUAD:LI21:401:EDES",
         readback_name="QUAD:LI21:401:EACT",
         description="This will be the description of the PV",
         tolerance_abs=0.1,
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         editable_popup = PVDetailsPopupEditable(tag_groups=tag_groups, pv_details=pv_details)
         if editable_popup.exec_() == QDialog.Accepted:
             print("PV Details Submitted:")
-            print(f"PV Name: {editable_popup.pv_details.pv_name}")
+            print(f"Setpoint Name: {editable_popup.pv_details.setpoint_name}")
             print(f"Readback Name: {editable_popup.pv_details.readback_name}")
             print(f"Description: {editable_popup.pv_details.description}")
             print(f"Absolute Tolerance: {editable_popup.pv_details.tolerance_abs}")

--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -345,7 +345,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             logging.exception(e)
 
         pv_details = PVDetails(
-            pv_name=data.setpoint,
+            setpoint_name=data.setpoint,
             readback_name=data.readback,
             description=data.description,
             tolerance_abs=data.abs_tolerance,
@@ -397,7 +397,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         def add_pv():
             try:
                 pv = self.client.backend.add_pv(
-                    self.popup.pv_details.pv_name or None,
+                    self.popup.pv_details.setpoint_name or None,
                     self.popup.pv_details.readback_name or None,
                     self.popup.pv_details.description,
                     abs_tolerance=self.popup.pv_details.tolerance_abs,


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Change fields in `PVDetailsPopup` and `PVDetailsPopupEditable` from "PV Name" to "Setpoint Name" for consistency across Squirrel. Also changed the attribute name of `PVDetails.pv_name` to `PVDetails.setpoint_name` for consistency.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[SWAPPS-368](https://jira.slac.stanford.edu/browse/SWAPPS-368)

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="200" height="456" alt="Screenshot 2025-10-07 at 11 22 06" src="https://github.com/user-attachments/assets/51fc2f45-0607-4cda-b5aa-a4eb268a0df4" />
<img width="328" height="334" alt="Screenshot 2025-10-07 at 11 22 12" src="https://github.com/user-attachments/assets/063ea711-35c2-44c4-ad91-c1fb24731aa7" />

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
