### PR TITLE
ENH: Add bug report button and update sidebar toggle layout

### DIFF
--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -551,7 +551,6 @@ class NavigationPanel(QtWidgets.QWidget):
             self.expanded = value
             if self.expanded:
                 self.toggle_and_bug_layout.setDirection(QtWidgets.QBoxLayout.LeftToRight)
-                self.toggle_and_bug_layout.addStretch()
                 self.toggle_and_bug_layout.addWidget(self.bug_report_button)
                 self.toggle_expand_button.setIcon(qta.icon("ph.arrow-line-left"))
                 self.view_snapshots_button.setText("View Snapshots")
@@ -562,8 +561,8 @@ class NavigationPanel(QtWidgets.QWidget):
                     button.setProperty("icon-only", False)
                 self.save_button.setProperty("icon-only", False)
             else:
-                self.toggle_and_bug_layout.setDirection(QtWidgets.QBoxLayout.TopToBottom)
-                self.toggle_and_bug_layout.insertWidget(0, self.bug_report_button, alignment=QtCore.Qt.AlignCenter)
+                self.toggle_and_bug_layout.setDirection(QtWidgets.QBoxLayout.BottomToTop)
+                self.toggle_and_bug_layout.insertWidget(1, self.bug_report_button, alignment=QtCore.Qt.AlignCenter)
                 self.toggle_expand_button.setIcon(qta.icon("ph.arrow-line-right"))
                 for button in self.nav_buttons:
                     button.setText("")


### PR DESCRIPTION
## Description
- Added a bug report button with a tooltip and a click handler to open an external Microsoft Forms link.
- Included error handling if the external form cannot be opened.
- Updated the sidebar layout to have expand icon and bug icon side-by-side when expanded. When collapsed, the bug icon is stacked above the expand button.
- Implemented layout direction switching in set_expanded().

## Motivation
[SWAPPS-407](https://jira.slac.stanford.edu/browse/SWAPPS-407)

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="500" height="433" alt="Screenshot 2025-10-09 at 9 05 41 AM" src="https://github.com/user-attachments/assets/ba231402-7adc-4b57-9a08-010f0c79a12a" />
<img width="150" height="136" alt="Screenshot 2025-10-09 at 9 06 03 AM" src="https://github.com/user-attachments/assets/5f163188-17d3-46b8-899c-9a90c3a22856" />
<img width="500" height="436" alt="Screenshot 2025-10-09 at 9 06 16 AM" src="https://github.com/user-attachments/assets/c4842657-23fc-4711-9d22-d313ef1b2362" />


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
