### PR TITLE
FIX: Device Field in `PVDetailsPopupEditable`

### DIFF
--- a/squirrel/widgets/pv_details_components.py
+++ b/squirrel/widgets/pv_details_components.py
@@ -181,6 +181,7 @@ class PVDetailsPopupEditable(QDialog):
         self.tolerance_rel_input.setValidator(validator)
 
         if pv_details:
+            self.device_input.setText(pv_details.device)
             self.setpoint_name_input.setText(pv_details.setpoint_name)
             self.readback_name_input.setText(pv_details.readback_name)
             self.description_input.setText(pv_details.description)


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Noticed a bug with #75 that does not set the initial text for `PVDetailsPopupEditable.device_input`.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Populating the field on initialization would be nice.

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="328" height="408" alt="Screenshot 2025-10-10 at 13 53 20" src="https://github.com/user-attachments/assets/620ce8a2-6940-461b-a0de-55a602375b5e" />

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
