### PR TITLE
FIX: `MongoBackend.update_pv()` Updates Readbacks

### DIFF
--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -337,7 +337,7 @@ class MongoBackend(_Backend):
         pv_dicts = r.json()["payload"]
         return [self._unpack_pv(pv_dict) for pv_dict in pv_dicts]
 
-    def update_pv(self, pv_id, setpoint="", description="", device="", tags=None, abs_tolerance=None, rel_tolerance=None) -> None:
+    def update_pv(self, pv_id, setpoint="", readback="", description="", device="", tags=None, abs_tolerance=None, rel_tolerance=None) -> None:
         """
         Update PV in the backend. Data will be updated for any passed parameter;
         data for other parameters will not be affected.
@@ -348,6 +348,8 @@ class MongoBackend(_Backend):
             ID of the PV to update
         setpoint : str, optional
             A new setpoint address
+        readback : str, optional
+            A new readback address
         description : str, optional
             A new description
         device : str, optional
@@ -366,6 +368,8 @@ class MongoBackend(_Backend):
         body = {}
         if setpoint:
             body["setpointAddress"] = setpoint
+        if readback:
+            body["readbackAddress"] = readback
         if description:
             body["description"] = description
         if device:

--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -382,6 +382,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.client.backend.update_pv(
             pv_id,
             setpoint=pv_details.setpoint_name,
+            readback=pv_details.readback_name,
             description=pv_details.description,
             device=pv_details.device,
             tags=pv_details.tags,


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Fix a missing field in the method `MongoBackend.update_pv()` so that the readback field can be altered by the user. Also fix the method's callers.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`MongoBackend.update_pv()` did not offer a way for users to change the readback field for PVs.

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="1040" height="552" alt="Screenshot 2025-10-10 at 14 00 39" src="https://github.com/user-attachments/assets/740ccd70-76df-4113-9d68-c7be6af8c86a" />
<img width="1040" height="552" alt="Screenshot 2025-10-10 at 14 01 34" src="https://github.com/user-attachments/assets/ea592d0a-1e8b-4194-a62f-279ce5c611ef" />


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
