### PR TITLE
FIX: Reference Source Model's Row Index for Refetch

### DIFF
--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -331,14 +331,14 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
             return
         data: PV
         if isinstance(index.model(), QtCore.QSortFilterProxyModel):
-            source_model = index.model().sourceModel()
-            source_index = index.model().mapToSource(index)
+            model = index.model().sourceModel()
+            row = index.model().mapToSource(index).row()
         elif isinstance(index.model(), PVTableModel):
-            source_model = index.model()
-            source_index = index
+            model = index.model()
+            row = index.row()
         else:
             raise TypeError("Invalid model type passed to open_pv_details")
-        data = source_model._data[source_index.row()]
+        data = model._data[row]
 
         # Get data via the client for alarm limits
         epics_data: EpicsData = None
@@ -368,7 +368,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         )
         if editable:
             self.popup.accepted.connect(self.update_pv)
-            self.popup.accepted.connect(lambda: source_model.refetch_row(source_index.row()))
+            self.popup.accepted.connect(lambda: model.refetch_row(row))
         self.popup.adjustSize()
 
         table_top_right = view.mapToGlobal(view.rect().topRight())

--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -368,7 +368,7 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         )
         if editable:
             self.popup.accepted.connect(self.update_pv)
-            self.popup.accepted.connect(lambda: view.model().sourceModel().refetch_row(index.row()))
+            self.popup.accepted.connect(lambda: source_model.refetch_row(source_index.row()))
         self.popup.adjustSize()
 
         table_top_right = view.mapToGlobal(view.rect().topRight())

--- a/squirrel/widgets/window.py
+++ b/squirrel/widgets/window.py
@@ -333,11 +333,12 @@ class Window(QtWidgets.QMainWindow, metaclass=QtSingleton):
         if isinstance(index.model(), QtCore.QSortFilterProxyModel):
             source_model = index.model().sourceModel()
             source_index = index.model().mapToSource(index)
-            data = source_model._data[source_index.row()]
         elif isinstance(index.model(), PVTableModel):
-            data = index.model()._data[index.row()]
+            source_model = index.model()
+            source_index = index
         else:
             raise TypeError("Invalid model type passed to open_pv_details")
+        data = source_model._data[source_index.row()]
 
         # Get data via the client for alarm limits
         epics_data: EpicsData = None


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Found a bug that prevented the `PVBrowserTable` from showing changes made to rows if the table was being filtered.

This was because the call to `PVBrowserTableModel.refetch_row()` was being given the index's row value on the filtered model. This PR changes it to get the correct row value regardless of the model being filtered or not.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users will probably filter this table more often than not, so it should work as expected when being filtered.

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
