### PR TITLE
MNT: return Iterable not Generator in _Backend.search

### DIFF
--- a/squirrel/backends/core.py
+++ b/squirrel/backends/core.py
@@ -2,8 +2,8 @@
 Base squirrel data storage backend interface
 """
 import re
-from collections.abc import Container, Generator
-from typing import NamedTuple, Sequence, Union
+from collections.abc import Container
+from typing import Iterable, NamedTuple, Sequence, Union
 from uuid import UUID
 
 from squirrel.model import PV, Snapshot
@@ -56,9 +56,9 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def search(self, *search_terms: SearchTermType) -> Generator[Entry, None, None]:
+    def search(self, *search_terms: SearchTermType) -> Iterable[Union[PV, Snapshot]]:
         """
-        Yield Entry objects matching all ``search_terms``. Each SearchTerm has the format
+        Return all entries matching all ``search_terms``. Each SearchTerm has the format
         (<attr>, <operator>, <value>).  Some operators take tuples as values.
 
         The supported operators are:

--- a/squirrel/backends/mongo.py
+++ b/squirrel/backends/mongo.py
@@ -52,6 +52,7 @@ class MongoBackend(_Backend):
                     entries = self.get_snapshots(meta_pvs=meta_pvs)
                 else:
                     entries = self.get_all_pvs()
+        matching = []
         for entry in entries:
             conditions = []
             for attr, op, target in search_terms:
@@ -67,7 +68,8 @@ class MongoBackend(_Backend):
                     except AttributeError:
                         conditions.append(False)
             if all(conditions):
-                yield entry
+                matching.append(entry)
+        return matching
 
     def get_tags(self) -> TagDef:
         """

--- a/squirrel/backends/test.py
+++ b/squirrel/backends/test.py
@@ -25,6 +25,7 @@ class TestBackend(_Backend):
         self.meta_pvs = meta_pvs or []
 
     def search(self, *search_terms: SearchTermType):
+        matching = []
         for entry in self.pvs + self.snapshots:
             conditions = []
             for attr, op, target in search_terms:
@@ -38,7 +39,8 @@ class TestBackend(_Backend):
                     except AttributeError:
                         conditions.append(False)
             if all(conditions):
-                yield entry
+                matching.append(entry)
+        return matching
 
     def get_tags(self) -> TagDef:
         return self.tag_groups.copy()

--- a/squirrel/bin/demo_main.py
+++ b/squirrel/bin/demo_main.py
@@ -51,6 +51,6 @@ def main(*args, db_path=None, **kwargs):
     source_names = parser.get("demo", "fixtures").split()
     populate_backend(client.backend, source_names)
     # IOCFactory needs the Entries with data
-    filled = list(client.search(("entry_type", "eq", PV)))
+    filled = client.search(("entry_type", "eq", PV))
     with IOCFactory.from_entries(filled, client)(prefix=''):
         ui_main(cfg_path=DEMO_CONFIG)

--- a/squirrel/tables/pv_browser_table.py
+++ b/squirrel/tables/pv_browser_table.py
@@ -38,9 +38,7 @@ class PVBrowserTableModel(QtCore.QAbstractTableModel):
     def __init__(self, client, parent=None):
         super().__init__(parent=parent)
         self.client = client
-        self._data = list(self.client.search(
-            ("entry_type", "eq", PV),
-        ))
+        self._data = self.client.search(("entry_type", "eq", PV))
 
     def rowCount(self, _=QtCore.QModelIndex()) -> int:
         return len(self._data)
@@ -122,11 +120,9 @@ class PVBrowserTableModel(QtCore.QAbstractTableModel):
     def refetch_row(self, row):
         index = self.index(row, PV_BROWSER_HEADER.PV.value)
         pv_id = self.data(index, QtCore.Qt.UserRole).uuid
-        pv = list(
-            self.client.search(
-                ("entry_type", "eq", PV),
-                ("uuid", "eq", pv_id),
-            )
+        pv = self.client.search(
+            ("entry_type", "eq", PV),
+            ("uuid", "eq", pv_id),
         )[0]
         self._data[row] = pv
         self.dataChanged.emit(index, index)

--- a/squirrel/tables/pv_table.py
+++ b/squirrel/tables/pv_table.py
@@ -208,16 +208,14 @@ class PVTableModel(LivePVTableModel):
         try:
             entries = snapshot.pvs
         except AttributeError:
-            entries = list(self.client.search(
+            entries = self.client.search(
                 ("ancestor", "eq", snapshot),
                 ("entry_type", "eq", PV),
-            ))
+            )
         finally:
             self._data = [
-                entry if isinstance(entry, PV) else list(
-                    self.client.search(
-                        ("uuid", "eq", entry)
-                    )
+                entry if isinstance(entry, PV) else self.client.search(
+                    ("uuid", "eq", entry)
                 )[0] for entry in entries
             ]
         self._checked = set()

--- a/squirrel/tests/test_backend.py
+++ b/squirrel/tests/test_backend.py
@@ -43,56 +43,56 @@ def test_search_entry(test_backend: _Backend):
     results = test_backend.search(
         SearchTerm('description', 'eq', 'Snapshot 1')
     )
-    assert len(list(results)) == 1
+    assert len() == 1
     # Search by field name
     results = test_backend.search(
         SearchTerm('uuid', 'eq', UUID('ffd668d3-57d9-404e-8366-0778af7aee61'))
     )
-    assert len(list(results)) == 1
+    assert len(results) == 1
     # Search by field name
     results = test_backend.search(
         SearchTerm('data', 'eq', 2)
     )
-    assert len(list(results)) == 2
+    assert len(results) == 2
     # Search by field name
     results = test_backend.search(
         SearchTerm('uuid', 'eq', UUID('ecb42cdb-b703-4562-86e1-45bd67a2ab1a')),
         SearchTerm('data', 'eq', 2)
     )
-    assert len(list(results)) == 1
+    assert len(results) == 1
 
     results = test_backend.search(
         SearchTerm('entry_type', 'eq', Snapshot)
     )
-    assert len(list(results)) == 1
+    assert len(results) == 1
 
     results = test_backend.search(
         SearchTerm('entry_type', 'in', (Snapshot))
     )
-    assert len(list(results)) == 2
+    assert len(results) == 2
 
     results = test_backend.search(
         SearchTerm('data', 'lt', 3)
     )
-    assert len(list(results)) == 3
+    assert len(results) == 3
 
     results = test_backend.search(
         SearchTerm('data', 'gt', 3)
     )
-    assert len(list(results)) == 1
+    assert len(results) == 1
 
 
 @setup_test_stack(
     sources=["sample_database"], backend_type=[TestBackend]
 )
 def test_fuzzy_search(test_backend: _Backend):
-    results = list(test_backend.search(
-        SearchTerm('description', 'like', 'motor'))
+    results = test_backend.search(
+        SearchTerm('description', 'like', 'motor')
     )
     assert len(results) == 3
 
-    results = list(test_backend.search(
-        SearchTerm('description', 'like', 'motor field (?!PREC)'))
+    results = test_backend.search(
+        SearchTerm('description', 'like', 'motor field (?!PREC)')
     )
     assert len(results) == 2
 
@@ -101,22 +101,22 @@ def test_fuzzy_search(test_backend: _Backend):
     sources=["sample_database"], backend_type=[TestBackend]
 )
 def test_tag_search(test_backend: _Backend):
-    results = list(test_backend.search(
+    results = test_backend.search(
         SearchTerm('tags', 'gt', {})
-    ))
+    )
     assert len(results) == 4
 
     smaller_tag_set = {0: {1}}
     bigger_tag_set = {0: {0, 1}}
 
-    results = list(test_backend.search(
+    results = test_backend.search(
         SearchTerm('tags', 'gt', smaller_tag_set)
-    ))
+    )
     assert len(results) == 2
 
-    results = list(test_backend.search(
+    results = test_backend.search(
         SearchTerm('tags', 'gt', bigger_tag_set)
-    ))
+    )
     assert len(results) == 0
 
 
@@ -126,15 +126,13 @@ def test_tag_search(test_backend: _Backend):
 )
 def test_search_error(test_backend: _Backend):
     with pytest.raises(TypeError):
-        results = test_backend.search(
+        test_backend.search(
             SearchTerm('data', 'like', 5)
         )
-        list(results)
     with pytest.raises(ValueError):
-        results = test_backend.search(
+        test_backend.search(
             SearchTerm('data', 'near', 5)
         )
-        list(results)
 
 
 @pytest.mark.skip(reason="Rewrite to test update_pv")
@@ -143,16 +141,16 @@ def test_search_error(test_backend: _Backend):
 )
 def test_update_entry(test_backend: _Backend):
     # grab an entry from the database and modify it.
-    entry = list(test_backend.search(
+    entry = test_backend.search(
         SearchTerm('description', 'eq', 'collection 1 defining some motor fields')
-    ))[0]
+    )[0]
     old_uuid = entry.uuid
 
     entry.description = 'new_description'
     test_backend.update_entry(entry)
-    new_entry = list(test_backend.search(
+    new_entry = test_backend.search(
         SearchTerm('description', 'eq', 'new_description')
-    ))[0]
+    )[0]
     new_uuid = new_entry.uuid
 
     assert old_uuid == new_uuid

--- a/squirrel/tests/test_client.py
+++ b/squirrel/tests/test_client.py
@@ -135,14 +135,14 @@ def test_find_config(sscore_cfg: str):
 @pytest.mark.skip(reason="Rewrite search to check data values within Snapshots")
 @setup_test_stack(sources=["sample_database"], backend_type=TestBackend)
 def test_search(test_client):
-    results = list(test_client.search(
+    results = test_client.search(
         ('setpoint_data.data', 'isclose', (4, 0, 0))
-    ))
+    )
     assert len(results) == 0
 
-    results = list(test_client.search(
+    results = test_client.search(
         SearchTerm(operator='isclose', attr='setpoint_data.data', value=(4, .5, 1))
-    ))
+    )
     assert len(results) == 4
 
 
@@ -152,16 +152,16 @@ def test_search(test_client):
     backend_type=TestBackend
 )
 def test_search_entries_by_ancestor(test_client: Client):
-    entries = tuple(test_client.search(
+    entries = test_client.search(
         ("entry_type", "eq", PV),
         ("pv_name", "eq", "LASR:GUNB:TEST1"),
-    ))
+    )
     assert len(entries) == 2
-    entries = tuple(test_client.search(
+    entries = test_client.search(
         ("entry_type", "eq", PV),
         ("pv_name", "eq", "LASR:GUNB:TEST1"),
         ("ancestor", "eq", UUID("06282731-33ea-4270-ba14-098872e627dc")),  # top-level snapshot
-    ))
+    )
     assert len(entries) == 1
 
 
@@ -175,14 +175,14 @@ def test_search_caching(test_client: Client):
     result = test_client.search(
         ("ancestor", "eq", UUID("06282731-33ea-4270-ba14-098872e627dc")),
     )
-    assert len(tuple(result)) == 13
+    assert len(result) == 13
     entry.pvs = []
     test_client.backend.update_entry(entry)
     result = test_client.search(
         ("ancestor", "eq", UUID("06282731-33ea-4270-ba14-098872e627dc")),
     )
-    assert len(tuple(result)) == 1  # update is picked up in new search
+    assert len(result) == 1  # update is picked up in new search
 
 
 def test_parametrized_filestore_empty(test_client: Client):
-    assert len(list(test_client.search())) == 0
+    assert len(test_client.search()) == 0

--- a/squirrel/tests/test_window.py
+++ b/squirrel/tests/test_window.py
@@ -34,13 +34,13 @@ def test_main_window(qtbot: QtBot, test_client: Client):
 def test_take_snapshot(qtbot, test_client):
     window = Window(client=test_client)
     qtbot.addWidget(window)
-    collection = tuple(test_client.search(("uuid", "eq", UUID("a9f289d4-3421-4107-8e7f-2fe0daab77a5"))))[0]
-    snapshot = tuple(test_client.search(("uuid", "eq", UUID("ffd668d3-57d9-404e-8366-0778af7aee61"))))[0]
+    collection = test_client.search(("uuid", "eq", UUID("a9f289d4-3421-4107-8e7f-2fe0daab77a5")))[0]
+    snapshot = test_client.search(("uuid", "eq", UUID("ffd668d3-57d9-404e-8366-0778af7aee61")))[0]
 
     collection_page = window.open_page(collection)
     new_snapshot = collection_page.take_snapshot()
     collection_page.children()[-1].done(1)
-    search_result = tuple(test_client.search(("uuid", "eq", new_snapshot.uuid)))
+    search_result = test_client.search(("uuid", "eq", new_snapshot.uuid))
     assert new_snapshot == search_result[0]
 
     snapshot_page = window.open_page(snapshot)
@@ -52,7 +52,7 @@ def test_take_snapshot(qtbot, test_client):
     snapshot_page = window.open_page(snapshot)
     new_snapshot = snapshot_page.take_snapshot()
     snapshot_page.children()[-1].done(1)
-    search_result = tuple(test_client.search(("uuid", "eq", new_snapshot.uuid)))
+    search_result = test_client.search(("uuid", "eq", new_snapshot.uuid))
     assert new_snapshot == search_result[0]
 
 


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* change return hint and docstring in `_Backend.search`
* replace yield pattern with return in `MongoBackend.search` and `TestBackend.search`
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Returning a generator doesn't provide any benefit with the existing implementation, and removing it makes relevant code a little more convenient to work with.

Closes [SWAPPS-347](https://jira.slac.stanford.edu/browse/SWAPPS-347)
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
