### PR TITLE
DOC: Specify python version in conda env instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Installation
 
 ::
 
-  $ conda create --name squirrel pip python<=3.13
+  $ conda create --name squirrel pip "python<=3.13"
   $ conda activate squirrel
   $
   $ conda install --file requirements.txt  # install statically, and only include packages necessary to run


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
* add `python<=3.13` to `conda create` step in README instructions
## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since python v3.14 was released, conda tries to install it when no maximum version is specified. This is incompatible with aioca / epicscorelibs, so we have to create the conda environment with v3.13 or lower.
<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
