### PR TITLE
FIX: correctly center all columns except for PV Name

### DIFF
--- a/squirrel/tables/pv_table.py
+++ b/squirrel/tables/pv_table.py
@@ -155,9 +155,8 @@ class PVTableModel(LivePVTableModel):
                     return font
             return None
         elif role == QtCore.Qt.TextAlignmentRole:
-            if column not in [PV_HEADER.DEVICE, PV_HEADER.PV] or index.data() != NO_DATA:
-                return None
-            return QtCore.Qt.AlignCenter
+            if column not in [PV_HEADER.PV]:
+                return QtCore.Qt.AlignCenter
         elif role == QtCore.Qt.UserRole:
             return entry
         return None


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Updates the conditions to trigger center alignment for columns in PVTableModel. Now, all columns (except PV Name, which benefits from being left aligned) are center aligned.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looks better this way, resolves https://jira.slac.stanford.edu/browse/SWAPPS-455

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

<img width="1785" height="821" alt="image" src="https://github.com/user-attachments/assets/daa91480-97ba-484c-9fc8-63a3c7e36f61" />


## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
