### PR TITLE
FIX: Keep margins for tags correct when resizing their columns

### DIFF
--- a/squirrel/widgets/tag.py
+++ b/squirrel/widgets/tag.py
@@ -56,10 +56,10 @@ class TagChip(QtWidgets.QFrame):
     def paintEvent(self, event):
         painter = QtGui.QPainter(self)
         margins = self.contentsMargins()
-        if event.rect().width() > self.sizeHint().width():
+        if event.rect().width() >= self.sizeHint().width():
             margins.setLeft((event.rect().width() - self.sizeHint().width()) // 2)
             margins.setRight((event.rect().width() - self.sizeHint().width()) // 2)
-        if event.rect().height() > self.sizeHint().height():
+        if event.rect().height() >= self.sizeHint().height():
             margins.setTop((event.rect().height() - self.sizeHint().height()) // 2)
             margins.setBottom((event.rect().height() - self.sizeHint().height()) // 2)
         self.setContentsMargins(margins)


### PR DESCRIPTION
## Description
Fixes the issue described here when typing a long tag name and saving followed by a short tag name and saving can cause distortion in the size of other chips in the column:

https://github.com/slaclab/squirrel/pull/48#issuecomment-3084745926

Basically when the first resize happens, the margins of all the chips are adjusted to match the expanded width of the column they are in since the `if event.rect().width() > self.sizeHint().width():` check is True for all of them.

The second resize shrinks the width back down to that of the chip with the longest name, subsystem in this case. But since the event width and the tag chip width are now equal, the if check is no longer true for subsystem, so the subsystem tag does not have its margins re-computed properly.

Fix is just to also adjust the margins if the event width and the tag width are equal.

Verified tags still look fine on other pages as well.

## Motivation

Fixes https://jira.slac.stanford.edu/browse/SWAPPS-302

## Screenshots

![squirrel](https://github.com/user-attachments/assets/d587a338-e033-405e-8b91-07907fc45fa7)


## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
