### PR TITLE
ENH: Update PVTableModel column names and add Readback Addr

### DIFF
--- a/squirrel/tables/pv_table.py
+++ b/squirrel/tables/pv_table.py
@@ -108,7 +108,7 @@ class PVTableModel(LivePVTableModel):
                 return entry.device or NO_DATA
             elif column == PV_HEADER.PV:
                 return entry.setpoint
-            elif column == PV_HEADER.READBACK:
+            elif column == PV_HEADER.READBACK_ADDR:
                 sp = entry.setpoint
                 rb = entry.readback
                 return self.format_readback_addr(sp, rb)


### PR DESCRIPTION
## Description
- Created helper function to truncate readback addresses when matching setpoint prefixes
- Prepended "-:" to readback addresses to indicate continuation
- Renamed value columns:
    * "PV Name" -> "Setpoint Addr"
    * "Saved Value" -> "Saved SP"
    * "Live Value" -> "Live SP"
    * "Saved Readback" -> "Saved RB"
    * "Live Readback" -> "Live RB"

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
This change adds the Readback Address to the PV Table and helps conserve space through shortening the column display names.
A design decision was made to add "-:" before the readback address to signify that it is a truncated value.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes [SWAPPS-419](https://jira.slac.stanford.edu/secure/RapidBoard.jspa?rapidView=216&projectKey=SWAPPS&view=detail&selectedIssue=SWAPPS-419#)

<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots
<img width="1312" height="766" alt="Screenshot 2025-11-17 at 3 22 06 PM" src="https://github.com/user-attachments/assets/717c86ff-510e-4c71-a763-4caf0a0c492f" />


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
