### PR TITLE
ENH: Connect the create/update/delete actions for tags to the mongo backend

### DIFF
--- a/squirrel/pages/tag.py
+++ b/squirrel/pages/tag.py
@@ -191,6 +191,7 @@ class TagsDialog(QDialog):
                 QMessageBox.warning(self, "Duplicate Tag",
                                     f"The tag '{tag}' already exists.")
             else:
+                # Use the tag name as a temporary key, replaced by tag id from the backend when the user chooses to save
                 self.tags_dict[tag] = tag
                 self.populate_tag_list()
 

--- a/squirrel/tests/test_tag_page.py
+++ b/squirrel/tests/test_tag_page.py
@@ -107,7 +107,6 @@ def test_tagsdialog_add_new_tag(monkeypatch: pytest.MonkeyPatch, app: QApplicati
     dlg = _dlg()
 
     monkeypatch.setattr(QInputDialog, "getText", lambda *_a, **_k: ("three", True))
-    monkeypatch.setattr(TestBackend, "add_tag_to_group", lambda *_a, **_k: "dummy_id")
     dlg.add_new_tag()
 
     assert "three" in dlg.tags_dict.values()
@@ -118,7 +117,6 @@ def test_tagsdialog_edit_tag(monkeypatch: pytest.MonkeyPatch, app: QApplication)
     """`edit_tag` renames a tag after confirmation."""
     dlg = _dlg()
     monkeypatch.setattr(QInputDialog, "getText", lambda *_a, **_k: ("uno", True))
-    monkeypatch.setattr(TestBackend, "update_tag_in_group", lambda *_a, **_k: None)
     dlg.edit_tag(0, 0)
     assert dlg.tags_dict[0] == "uno"
 
@@ -127,7 +125,6 @@ def test_tagsdialog_remove_tag(monkeypatch: pytest.MonkeyPatch, app: QApplicatio
     """`remove_tag` deletes the entry when the user clicks *Yes*."""
     dlg = _dlg()
     monkeypatch.setattr(QMessageBox, "question", lambda *_: QMessageBox.Yes)
-    monkeypatch.setattr(TestBackend, "delete_tag_from_group", lambda *_a, **_k: None)
     dlg.remove_tag(0)
     assert 0 not in dlg.tags_dict
     assert dlg.tag_list.rowCount() == 1


### PR DESCRIPTION
## Description

Mongo returns string IDs for groups and tags when creating and fetching them. This PR updates the tag page to use these returned string IDs instead of maintaining a separate integer ID that is local to the page only. Then we can just use these IDs to update and delete tags as well.

## Motivation

Fixes https://jira.slac.stanford.edu/browse/SWAPPS-365, along with update/delete as well.

## Screenshots

![squirrel](https://github.com/user-attachments/assets/89c857f3-1f0d-43ab-acdd-47955a226eda)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
