### PR TITLE
BUG: Fix missing title label on preloaded snapshot details

### DIFF
--- a/squirrel/pages/snapshot_details.py
+++ b/squirrel/pages/snapshot_details.py
@@ -36,7 +36,7 @@ class SnapshotDetailsPage(Page):
         """
         super().__init__(parent)
         self.client = client
-        self.snapshot = snapshot
+        self.snapshot = None
 
         self.init_ui()
         if snapshot is not None:


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->

In SnapshotDetailsPage, set_snapshot() is what is intended to set self.snapshot and triggers the title label update, but setting self.snapshot in the init triggers an early return which bypasses this.
This change preserves the performance benefit of preloading the first snapshot while still executing the code to set the labels.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a bug where the preloaded snapshot was missing the title labels

<img width="1800" height="1005" alt="image" src="https://github.com/user-attachments/assets/abc5858d-fa6c-46c4-be7d-e05718fbf493" />


<!--
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots

<img width="723" height="221" alt="image" src="https://github.com/user-attachments/assets/0b78b416-f399-45b9-9178-0e650cc78bfc" />


## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
<!-- - [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page -->
